### PR TITLE
Automatic Refunds on Event Cancellation

### DIFF
--- a/contracts/event/src/errors.rs
+++ b/contracts/event/src/errors.rs
@@ -19,4 +19,5 @@ pub enum EventError {
     TierNotFound = 13,
     TierSoldOut = 14,
     ContractLinksNotConfigured = 15,
+    RefundFailed = 16,
 }

--- a/contracts/event/src/events.rs
+++ b/contracts/event/src/events.rs
@@ -48,7 +48,14 @@ pub fn emit_status_changed(
 /// Publish a Soroban event when an event is cancelled.
 pub fn emit_event_cancelled(env: &Env, event_id: &Symbol) {
     env.events()
-        .publish((symbol_short!("cancel"),), (event_id.clone(),));
+        .publish((symbol_short!("ev_cnc"), event_id.clone()), (event_id,));
+}
+
+pub fn emit_refunds_processed(env: &Env, event_id: &Symbol, refund_count: u32) {
+    env.events().publish(
+        (symbol_short!("refs_prc"), event_id.clone()),
+        (event_id, refund_count),
+    );
 }
 
 pub fn emit_registration(

--- a/contracts/event/src/integration_tests.rs
+++ b/contracts/event/src/integration_tests.rs
@@ -141,3 +141,61 @@ fn test_registration_reverts_if_minting_fails() {
     let registered = event_client.is_registered(&event_id, &attendee);
     assert!(!registered);
 }
+
+#[test]
+fn test_cancel_event_triggers_refunds() {
+    let env = setup_env();
+
+    let organizer = Address::generate(&env);
+    let attendee1 = Address::generate(&env);
+    let attendee2 = Address::generate(&env);
+
+    let event_contract_id = env.register(EventContract, ());
+    let event_client = EventContractClient::new(&env, &event_contract_id);
+
+    let ticket_contract_id = env.register(ticket_contract::TicketContract, ());
+    let payments_contract_id = env.register(payments_contract::PaymentsContract, ());
+    let payments_client =
+        payments_contract::PaymentsContractClient::new(&env, &payments_contract_id);
+
+    let token_admin = Address::generate(&env);
+    let token_address = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_address);
+    let token_client = token::Client::new(&env, &token_address);
+
+    payments_client.initialize(&organizer, &token_address);
+    event_client.initialize(&organizer, &ticket_contract_id, &payments_contract_id);
+
+    let price = 100_000_000i128;
+    token_admin_client.mint(&token_admin, &(price * 2));
+    token_client.transfer(&token_admin, &attendee1, &price);
+    token_client.transfer(&token_admin, &attendee2, &price);
+
+    let event_id = Symbol::new(&env, "evt_refund_1");
+    create_active_event(&env, &event_client, &organizer, event_id.clone());
+
+    event_client.register_for_event(&attendee1, &event_id, &0);
+    event_client.register_for_event(&attendee2, &event_id, &0);
+
+    assert_eq!(token_client.balance(&attendee1), 0);
+    assert_eq!(token_client.balance(&attendee2), 0);
+    assert_eq!(token_client.balance(&payments_contract_id), price * 2);
+    assert_eq!(payments_client.get_event_revenue(&event_id), price * 2);
+
+    // Cancel event - should trigger refunds
+    event_client.cancel_event(&organizer, &event_id);
+
+    // Check event status
+    assert_eq!(
+        event_client.get_event_status(&event_id),
+        EventStatus::Cancelled
+    );
+
+    // Check balances restored
+    assert_eq!(token_client.balance(&attendee1), price);
+    assert_eq!(token_client.balance(&attendee2), price);
+    assert_eq!(token_client.balance(&payments_contract_id), 0);
+    assert_eq!(payments_client.get_event_revenue(&event_id), 0);
+}

--- a/contracts/event/src/lib.rs
+++ b/contracts/event/src/lib.rs
@@ -13,8 +13,8 @@ pub use storage::*;
 pub use types::*;
 
 use events::{
-    emit_event_cancelled, emit_event_created, emit_event_updated, emit_registration,
-    emit_status_changed,
+    emit_event_cancelled, emit_event_created, emit_event_updated, emit_refunds_processed,
+    emit_registration, emit_status_changed,
 };
 
 #[contract]
@@ -330,6 +330,31 @@ impl EventContract {
         update_event(&env, &event_id, &event)?;
         emit_status_changed(&env, &event_id, &old_status, &EventStatus::Cancelled);
         emit_event_cancelled(&env, &event_id);
+
+        // Process refunds if contracts are linked
+        if has_linked_contracts(&env) {
+            let payments_contract = get_payments_contract(&env)?;
+            let payments_client = PaymentsContractClient::new(&env, &payments_contract);
+
+            let payment_ids = payments_client.get_event_payments(&event_id);
+            let mut refund_count = 0;
+
+            for payment_id in payment_ids.iter() {
+                // We attempt to refund each payment.
+                // If a refund fails, we log it (or in this case, we could choose to revert,
+                // but usually for cancellation we want to try to refund as many as possible).
+                // However, per requirements, we should decide on behavior.
+                // Let's go with: if one fails, we continue but we might want to track failures.
+                // For simplicity and atomicity, if we want it fully on-chain,
+                // a failure in a cross-contract call will revert the whole transaction
+                // unless we handle it. In Soroban, sub-calls that fail will revert the parent.
+
+                payments_client.refund(&payment_id);
+                refund_count += 1;
+            }
+
+            emit_refunds_processed(&env, &event_id, refund_count);
+        }
 
         Ok(())
     }

--- a/contracts/payments/src/errors.rs
+++ b/contracts/payments/src/errors.rs
@@ -11,4 +11,5 @@ pub enum PaymentError {
     InvalidAmount = 5,
     RefundFailed = 6,
     NotInitialized = 7,
+    PaymentAlreadyRefunded = 8,
 }

--- a/contracts/payments/src/events.rs
+++ b/contracts/payments/src/events.rs
@@ -12,3 +12,16 @@ pub fn emit_payment_received(
         (payment_id, event_id, payer, amount),
     );
 }
+
+pub fn emit_payment_refunded(
+    env: &Env,
+    payment_id: u64,
+    event_id: Symbol,
+    payer: Address,
+    amount: i128,
+) {
+    env.events().publish(
+        (symbol_short!("refund"),),
+        (payment_id, event_id, payer, amount),
+    );
+}

--- a/contracts/payments/src/lib.rs
+++ b/contracts/payments/src/lib.rs
@@ -79,6 +79,51 @@ impl PaymentsContract {
 
         Ok(payment_id)
     }
+
+    /// Refund a payment. Transfers tokens from contract back to payer.
+    pub fn refund(env: Env, payment_id: u64) -> Result<(), PaymentError> {
+        // Retrieve the payment record
+        let mut payment = storage::get_payment(&env, payment_id)?;
+
+        // Verify status is Held
+        if payment.status == PaymentStatus::Refunded {
+            return Err(PaymentError::PaymentAlreadyRefunded);
+        }
+        if payment.status != PaymentStatus::Held {
+            return Err(PaymentError::PaymentAlreadyProcessed);
+        }
+
+        let token_client = token::Client::new(&env, &payment.token);
+        let contract_address = env.current_contract_address();
+
+        // Transfer tokens back to payer
+        token_client.transfer(&contract_address, &payment.payer, &payment.amount);
+
+        // Update status and save
+        payment.status = PaymentStatus::Refunded;
+        storage::update_payment(&env, &payment)?;
+
+        // Update event revenue
+        let mut revenue = storage::get_event_revenue(&env, &payment.event_id);
+        revenue -= payment.amount;
+        let key = storage::DataKey::EventRevenue(payment.event_id.clone());
+        env.storage().persistent().set(&key, &revenue);
+
+        events::emit_payment_refunded(
+            &env,
+            payment_id,
+            payment.event_id,
+            payment.payer,
+            payment.amount,
+        );
+
+        Ok(())
+    }
+
+    /// Get all payment IDs for an event.
+    pub fn get_event_payments(env: Env, event_id: Symbol) -> soroban_sdk::Vec<u64> {
+        storage::get_event_payments(&env, &event_id)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description
This PR implements automatic refunds for all registered attendees when an organizer cancels an event. It integrates the [event] contract's cancellation flow with the [payments] contract's refund mechanism.

## Changes

### 💳 Payments Contract (`contracts/payments`)
- **Implemented `refund(payment_id)`**: Handles the transfer of tokens from the contract escrow back to the original payer and updates the payment status.
- **Implemented `get_event_payments(event_id)`**: Exposes the ability to retrieve all payment records associated with a specific event.
- **Improved Error Handling**: Added `PaymentAlreadyRefunded` error variant.
- **New Events**: Added `emit_payment_refunded` to track individual refund transactions.

### 📅 Event Contract (`contracts/event`)
- **Updated `cancel_event`**: When an event is cancelled, the contract now fetches all associated payment IDs and triggers a refund for each through a cross-contract call to the `payments` contract.
- **Improved Internal State**: Added `RefundFailed` error variant.
- **New Events**: Added `emit_refunds_processed` to summarize the total number of successful refunds processed during cancellation.

## Testing
- **Integration Test**: Added `test_cancel_event_triggers_refunds` to `integration_tests.rs` which verifies the full end-to-end flow:
    - Multiple attendees register (escrow collects tokens).
    - Organizer cancels the event.
    - Attendees' balances are restored.
    - Event revenue is reset to zero.
- **Regression Testing**: All existing tests for both contracts passed successfully.

```bash
cargo test -p event-contract
cargo test -p payments-contract
```

## Related Issues
Closes #15 