### PR TITLE
Improve the ticketing/payment flow an operational/indexing support

### DIFF
--- a/contracts/event/src/lib.rs
+++ b/contracts/event/src/lib.rs
@@ -66,6 +66,7 @@ impl EventContract {
         }
 
         let mut tiers = soroban_sdk::Vec::new(&env);
+        let mut max_supply = 0u32;
         for (current_tier_id, tier_param) in params.initial_tiers.iter().enumerate() {
             if tier_param.name.is_empty() {
                 return Err(EventError::InvalidInput);
@@ -76,6 +77,9 @@ impl EventContract {
             if tier_param.price < 0 {
                 return Err(EventError::InvalidPrice);
             }
+            max_supply = max_supply
+                .checked_add(tier_param.capacity)
+                .ok_or(EventError::InvalidTicketCount)?;
 
             tiers.push_back(TicketTier {
                 tier_id: current_tier_id as u32,
@@ -117,6 +121,8 @@ impl EventContract {
             created_at: env.ledger().timestamp(),
             privacy_level: params.privacy_level.clone(),
             max_tickets_per_user: params.max_tickets_per_user,
+            max_supply,
+            sold_count: 0,
         };
 
         save_event(&env, &params.event_id, &event);
@@ -131,6 +137,7 @@ impl EventContract {
                 &params.allow_anonymous,
                 &params.requires_verification,
                 &params.max_tickets_per_user,
+                &event.max_supply,
             );
         }
         let privacy = storage::get_event_privacy(&env, &params.event_id);
@@ -211,6 +218,7 @@ impl EventContract {
                 &event.allow_anonymous,
                 &event.requires_verification,
                 &event.max_tickets_per_user,
+                &event.max_supply,
             );
         }
         emit_event_updated(&env, &event);
@@ -258,6 +266,10 @@ impl EventContract {
         if price < 0 {
             return Err(EventError::InvalidPrice);
         }
+        event.max_supply = event
+            .max_supply
+            .checked_add(capacity)
+            .ok_or(EventError::InvalidTicketCount)?;
 
         let new_tier_id = event.tiers.len();
         let new_tier = TicketTier {
@@ -318,7 +330,19 @@ impl EventContract {
                     if c == 0 || c >= 100_000 {
                         return Err(EventError::InvalidTicketCount);
                     }
+                    if c < tier.sold {
+                        return Err(EventError::InvalidTicketCount);
+                    }
+                    let new_max_supply = event
+                        .max_supply
+                        .checked_sub(tier.capacity)
+                        .and_then(|supply| supply.checked_add(c))
+                        .ok_or(EventError::InvalidTicketCount)?;
+                    if new_max_supply < event.sold_count {
+                        return Err(EventError::InvalidTicketCount);
+                    }
                     tier.capacity = c;
+                    event.max_supply = new_max_supply;
                 }
                 event.tiers.set(i, tier);
                 found = true;
@@ -587,6 +611,10 @@ impl EventContract {
         let index = tier_index.ok_or(EventError::TierNotFound)?;
         let mut tier = event.tiers.get(index).ok_or(EventError::TierNotFound)?;
 
+        if event.sold_count >= event.max_supply {
+            return Err(EventError::EventSoldOut);
+        }
+
         if !has_res && tier.sold + tier.reserved >= tier.capacity {
             return Err(EventError::TierSoldOut);
         }
@@ -622,6 +650,7 @@ impl EventContract {
         }
 
         tier.sold += 1;
+        event.sold_count += 1;
         event.tiers.set(index, tier.clone());
         update_event(&env, &event_id, &event)?;
         let privacy = storage::get_event_privacy(&env, &event_id);

--- a/contracts/event/src/test.rs
+++ b/contracts/event/src/test.rs
@@ -678,6 +678,8 @@ fn test_register_for_event_happy_path() {
 
     let event = client.get_event(&event_id);
     assert_eq!(event.tiers.get(0).unwrap().sold, 1);
+    assert_eq!(event.max_supply, 500);
+    assert_eq!(event.sold_count, 1);
 
     let registered = client.is_registered(&event_id, &attendee);
     assert!(registered);
@@ -741,8 +743,12 @@ fn test_register_for_event_sold_out_fails() {
     client.update_event_status(&organizer, &event_id, &EventStatus::Active);
 
     client.register_for_event(&1, &attendee1, &event_id, &0, &false, &None);
+    let event = client.get_event(&event_id);
+    assert_eq!(event.sold_count, 1);
+    assert_eq!(event.max_supply, 1);
+
     let result = client.try_register_for_event(&2, &attendee2, &event_id, &0, &false, &None);
-    assert_eq!(result.err(), Some(Ok(EventError::TierSoldOut)));
+    assert_eq!(result.err(), Some(Ok(EventError::EventSoldOut)));
 }
 
 #[test]

--- a/contracts/event/src/types.rs
+++ b/contracts/event/src/types.rs
@@ -46,6 +46,8 @@ pub struct Event {
     pub created_at: u64,
     pub privacy_level: PrivacyLevel,
     pub max_tickets_per_user: u32,
+    pub max_supply: u32,
+    pub sold_count: u32,
 }
 
 #[contracttype]

--- a/contracts/payments/Cargo.toml
+++ b/contracts/payments/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lints.clippy]
+too_many_arguments = "allow"
+
 [lib]
 crate-type = ["lib", "cdylib"]
 doctest = false

--- a/contracts/payments/src/errors.rs
+++ b/contracts/payments/src/errors.rs
@@ -32,4 +32,5 @@ pub enum PaymentError {
     UnsupportedVersion = 26,
     MaxTicketsReached = 27,
     EventSoldOut = 28,
+    NonceRequired = 29,
 }

--- a/contracts/payments/src/errors.rs
+++ b/contracts/payments/src/errors.rs
@@ -31,4 +31,5 @@ pub enum PaymentError {
     MigrationFailed = 25,
     UnsupportedVersion = 26,
     MaxTicketsReached = 27,
+    EventSoldOut = 28,
 }

--- a/contracts/payments/src/errors.rs
+++ b/contracts/payments/src/errors.rs
@@ -33,4 +33,5 @@ pub enum PaymentError {
     MaxTicketsReached = 27,
     EventSoldOut = 28,
     NonceRequired = 29,
+    ContractPaused = 30,
 }

--- a/contracts/payments/src/events.rs
+++ b/contracts/payments/src/events.rs
@@ -1,8 +1,13 @@
 use privacy_utils::{mask_address, MaskedAddress, PrivacyLevel};
 use soroban_sdk::{contractevent, Address, BytesN, Env, Symbol};
 
+fn event_type(env: &Env, name: &str) -> Symbol {
+    Symbol::new(env, name)
+}
+
 #[contractevent(data_format = "vec", topics = ["payment"])]
 pub struct PaymentReceived {
+    pub event_type: Symbol,
     pub payment_id: u64,
     pub event_id: Symbol,
     pub payer: MaskedAddress,
@@ -13,48 +18,68 @@ pub struct PaymentReceived {
 
 #[contractevent(data_format = "vec", topics = ["receipt_requested"])]
 pub struct PaymentReceiptRequested {
+    pub event_type: Symbol,
     pub payment_id: u64,
+    pub event_id: Symbol,
     pub email_hash: Option<BytesN<32>>,
+    pub requested_at: u64,
 }
 
-pub fn emit_payment_receipt_requested(env: &Env, payment_id: u64, email_hash: Option<BytesN<32>>) {
+pub fn emit_payment_receipt_requested(
+    env: &Env,
+    payment_id: u64,
+    event_id: Symbol,
+    email_hash: Option<BytesN<32>>,
+) {
     PaymentReceiptRequested {
+        event_type: event_type(env, "receipt_requested"),
         payment_id,
+        event_id,
         email_hash,
+        requested_at: env.ledger().timestamp(),
     }
     .publish(env);
 }
 
 #[contractevent(data_format = "vec", topics = ["refund"])]
 pub struct PaymentRefunded {
+    pub event_type: Symbol,
     pub payment_id: u64,
     pub event_id: Symbol,
     pub payer: MaskedAddress,
     pub amount: i128,
+    pub token: Address,
     pub refunded_at: u64,
 }
 
 #[contractevent(data_format = "vec", topics = ["ticket_issued"])]
 pub struct TicketIssued {
+    pub event_type: Symbol,
     pub ticket_id: u64,
     pub event_id: Symbol,
     pub owner: MaskedAddress,
     pub payment_id: u64,
+    pub issued_at: u64,
 }
 
 #[contractevent(data_format = "vec", topics = ["withdrawal"])]
 pub struct RevenueWithdrawn {
+    pub event_type: Symbol,
     pub event_id: Symbol,
     pub organizer: MaskedAddress,
     pub amount: i128,
+    pub token: Address,
+    pub to: Address,
     pub withdrawn_at: u64,
 }
 
 #[contractevent(data_format = "vec", topics = ["escrow_released"])]
 pub struct EscrowAutoReleased {
+    pub event_type: Symbol,
     pub event_id: Symbol,
     pub organizer: Address,
     pub amount: i128,
+    pub released_at: u64,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -69,6 +94,7 @@ pub fn emit_payment_received(
     level: &PrivacyLevel,
 ) {
     PaymentReceived {
+        event_type: event_type(env, "payment_received"),
         payment_id,
         event_id,
         payer: mask_address(env, &payer, level.clone()),
@@ -84,12 +110,17 @@ pub fn emit_revenue_withdrawn(
     event_id: Symbol,
     organizer: Address,
     amount: i128,
+    token: Address,
+    to: Address,
     level: &PrivacyLevel,
 ) {
     RevenueWithdrawn {
+        event_type: event_type(env, "revenue_withdrawn"),
         event_id,
         organizer: mask_address(env, &organizer, level.clone()),
         amount,
+        token,
+        to,
         withdrawn_at: env.ledger().timestamp(),
     }
     .publish(env);
@@ -101,13 +132,16 @@ pub fn emit_payment_refunded(
     event_id: Symbol,
     payer: Address,
     amount: i128,
+    token: Address,
     level: &PrivacyLevel,
 ) {
     PaymentRefunded {
+        event_type: event_type(env, "payment_refunded"),
         payment_id,
         event_id,
         payer: mask_address(env, &payer, level.clone()),
         amount,
+        token,
         refunded_at: env.ledger().timestamp(),
     }
     .publish(env);
@@ -122,28 +156,35 @@ pub fn emit_ticket_issued(
     level: &PrivacyLevel,
 ) {
     TicketIssued {
+        event_type: event_type(env, "ticket_issued"),
         ticket_id,
         event_id,
         owner: mask_address(env, &owner, level.clone()),
         payment_id,
+        issued_at: env.ledger().timestamp(),
     }
     .publish(env);
 }
 
 pub fn emit_escrow_auto_released(env: &Env, event_id: Symbol, organizer: Address, amount: i128) {
     EscrowAutoReleased {
+        event_type: event_type(env, "escrow_auto_released"),
         event_id,
         organizer,
         amount,
+        released_at: env.ledger().timestamp(),
     }
     .publish(env);
 }
 
 #[contractevent(data_format = "vec", topics = ["platform_fee"])]
 pub struct PlatformFeeCollected {
+    pub event_type: Symbol,
     pub event_id: Symbol,
     pub fee_amount: i128,
     pub organizer_amount: i128,
+    pub token: Address,
+    pub collected_at: u64,
 }
 
 pub fn emit_platform_fee_collected(
@@ -151,37 +192,63 @@ pub fn emit_platform_fee_collected(
     event_id: Symbol,
     fee_amount: i128,
     organizer_amount: i128,
+    token: Address,
 ) {
     PlatformFeeCollected {
+        event_type: event_type(env, "platform_fee_collected"),
         event_id,
         fee_amount,
         organizer_amount,
+        token,
+        collected_at: env.ledger().timestamp(),
     }
     .publish(env);
 }
 
 #[contractevent(data_format = "vec", topics = ["platform_fee_updated"])]
 pub struct PlatformFeeUpdated {
+    pub event_type: Symbol,
+    pub admin: Address,
     pub old_bps: u32,
     pub new_bps: u32,
+    pub updated_at: u64,
 }
 
-pub fn emit_platform_fee_updated(env: &Env, old_bps: u32, new_bps: u32) {
-    PlatformFeeUpdated { old_bps, new_bps }.publish(env);
+pub fn emit_platform_fee_updated(env: &Env, admin: Address, old_bps: u32, new_bps: u32) {
+    PlatformFeeUpdated {
+        event_type: event_type(env, "platform_fee_updated"),
+        admin,
+        old_bps,
+        new_bps,
+        updated_at: env.ledger().timestamp(),
+    }
+    .publish(env);
 }
 
 #[contractevent(data_format = "vec", topics = ["platform_withdrawal"])]
 pub struct PlatformRevenueWithdrawn {
+    pub event_type: Symbol,
     pub event_id: Symbol,
     pub amount: i128,
+    pub token: Address,
     pub to: Address,
+    pub withdrawn_at: u64,
 }
 
-pub fn emit_platform_revenue_withdrawn(env: &Env, event_id: Symbol, amount: i128, to: Address) {
+pub fn emit_platform_revenue_withdrawn(
+    env: &Env,
+    event_id: Symbol,
+    amount: i128,
+    token: Address,
+    to: Address,
+) {
     PlatformRevenueWithdrawn {
+        event_type: event_type(env, "platform_revenue_withdrawn"),
         event_id,
         amount,
+        token,
         to,
+        withdrawn_at: env.ledger().timestamp(),
     }
     .publish(env);
 }

--- a/contracts/payments/src/lib.rs
+++ b/contracts/payments/src/lib.rs
@@ -49,9 +49,18 @@ fn validate_payment_privacy(
     Ok(())
 }
 
+fn require_not_paused(env: &Env) -> Result<(), PaymentError> {
+    if storage::is_paused(env) {
+        return Err(PaymentError::ContractPaused);
+    }
+
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 fn create_payment(env: Env, params: PaymentParams) -> Result<u64, PaymentError> {
     params.payer.require_auth();
+    require_not_paused(&env)?;
 
     if params.nonce == 0 {
         return Err(PaymentError::NonceRequired);
@@ -245,6 +254,21 @@ impl PaymentsContract {
         storage::get_owner_tickets(&env, &owner)
     }
 
+    pub fn is_paused(env: Env) -> bool {
+        storage::is_paused(&env)
+    }
+
+    pub fn set_paused(env: Env, admin: Address, paused: bool) -> Result<(), PaymentError> {
+        let stored_admin = storage::get_admin(&env)?;
+        if admin != stored_admin {
+            return Err(PaymentError::Unauthorized);
+        }
+        admin.require_auth();
+
+        storage::set_paused(&env, paused);
+        Ok(())
+    }
+
     /// Set the current lifecycle status for an event.
     pub fn set_event_status(
         env: Env,
@@ -252,6 +276,7 @@ impl PaymentsContract {
         event_id: Symbol,
         status: EventStatus,
     ) -> Result<(), PaymentError> {
+        require_not_paused(&env)?;
         let stored_admin = storage::get_admin(&env)?;
         if admin != stored_admin {
             return Err(PaymentError::Unauthorized);
@@ -323,6 +348,7 @@ impl PaymentsContract {
         allow_anonymous: bool,
         requires_verification: bool,
     ) -> Result<(), PaymentError> {
+        require_not_paused(&env)?;
         if event_contract != storage::get_event_contract(&env)? {
             return Err(PaymentError::Unauthorized);
         }
@@ -349,6 +375,7 @@ impl PaymentsContract {
         max_tickets_per_user: u32,
         max_supply: u32,
     ) -> Result<(), PaymentError> {
+        require_not_paused(&env)?;
         if event_contract != storage::get_event_contract(&env)? {
             return Err(PaymentError::Unauthorized);
         }
@@ -395,6 +422,7 @@ impl PaymentsContract {
         payment_id: u64,
         amount: Option<i128>,
     ) -> Result<(), PaymentError> {
+        require_not_paused(&env)?;
         let stored_admin = storage::get_admin(&env)?;
         if admin != stored_admin {
             return Err(PaymentError::Unauthorized);
@@ -453,6 +481,7 @@ impl PaymentsContract {
     }
 
     pub fn withdraw(env: Env, organizer: Address, event_id: Symbol) -> Result<(), PaymentError> {
+        require_not_paused(&env)?;
         organizer.require_auth();
 
         let stored_organizer = storage::get_event_organizer(&env, &event_id)?;
@@ -559,6 +588,7 @@ impl PaymentsContract {
         organizer: Address,
         event_end_time: u64,
     ) -> Result<(), PaymentError> {
+        require_not_paused(&env)?;
         let stored_admin = storage::get_admin(&env)?;
         if admin != stored_admin {
             return Err(PaymentError::Unauthorized);
@@ -578,6 +608,7 @@ impl PaymentsContract {
     /// Permissionless: anyone can trigger this after expiry.
     /// Idempotent: calling after already released returns EscrowAlreadyReleased.
     pub fn release_if_expired(env: Env, event_id: Symbol) -> Result<(), PaymentError> {
+        require_not_paused(&env)?;
         let mut meta = storage::get_escrow_meta(&env, &event_id)?;
 
         if meta.auto_released {
@@ -628,6 +659,7 @@ impl PaymentsContract {
     /// to the specified address. Platform fees are accumulated for later
     /// withdrawal by the admin.
     pub fn withdraw_revenue(env: Env, event_id: Symbol, to: Address) -> Result<(), PaymentError> {
+        require_not_paused(&env)?;
         let admin = storage::get_admin(&env)?;
         admin.require_auth();
 
@@ -693,6 +725,7 @@ impl PaymentsContract {
 
     /// Update the platform fee (admin only). Fee is in basis points (0-10000).
     pub fn set_platform_fee(env: Env, fee_bps: u32, wallet: Address) -> Result<(), PaymentError> {
+        require_not_paused(&env)?;
         let admin = storage::get_admin(&env)?;
         admin.require_auth();
 
@@ -722,6 +755,7 @@ impl PaymentsContract {
     /// Withdraw accumulated platform fees for an event (admin only).
     /// Sends fees to the configured platform wallet.
     pub fn withdraw_platform_revenue(env: Env, event_id: Symbol) -> Result<(), PaymentError> {
+        require_not_paused(&env)?;
         let admin = storage::get_admin(&env)?;
         admin.require_auth();
 
@@ -754,6 +788,7 @@ impl PaymentsContract {
         event_id: Symbol,
         level: PrivacyLevel,
     ) -> Result<(), PaymentError> {
+        require_not_paused(&env)?;
         let stored_admin = storage::get_admin(&env)?;
         if admin != stored_admin {
             return Err(PaymentError::Unauthorized);
@@ -775,6 +810,7 @@ impl PaymentsContract {
 
     /// Migrate the contract to a new version. Only admin can call this.
     pub fn migrate(env: Env, admin: Address) -> Result<u32, PaymentError> {
+        require_not_paused(&env)?;
         admin.require_auth();
 
         let current_admin = storage::get_admin(&env)?;
@@ -824,6 +860,7 @@ impl PaymentsContract {
         event_id: Symbol,
         token_address: Address,
     ) -> Result<(), PaymentError> {
+        require_not_paused(&env)?;
         organizer.require_auth();
 
         match storage::get_event_status(&env, &event_id) {
@@ -884,6 +921,7 @@ impl PaymentsContract {
         organizer: Address,
         event_id: Symbol,
     ) -> Result<(), PaymentError> {
+        require_not_paused(&env)?;
         organizer.require_auth();
 
         match storage::get_event_status(&env, &event_id) {

--- a/contracts/payments/src/lib.rs
+++ b/contracts/payments/src/lib.rs
@@ -53,7 +53,11 @@ fn validate_payment_privacy(
 fn create_payment(env: Env, params: PaymentParams) -> Result<u64, PaymentError> {
     params.payer.require_auth();
 
-    if params.nonce != 0 && storage::has_nonce(&env, &params.payer, params.nonce) {
+    if params.nonce == 0 {
+        return Err(PaymentError::NonceRequired);
+    }
+
+    if storage::has_nonce(&env, &params.payer, params.nonce) {
         return Err(PaymentError::DuplicateRequest);
     }
 
@@ -111,9 +115,7 @@ fn create_payment(env: Env, params: PaymentParams) -> Result<u64, PaymentError> 
     storage::save_payment(&env, &payment)?;
     storage::add_event_payment(&env, &params.event_id, payment_id);
     storage::add_payer_payment(&env, &params.payer, payment_id);
-    if params.nonce != 0 {
-        storage::set_nonce(&env, &params.payer, params.nonce);
-    }
+    storage::set_nonce(&env, &params.payer, params.nonce);
     storage::add_event_revenue(&env, &params.event_id, params.amount);
 
     // Track token-specific revenue
@@ -184,7 +186,6 @@ fn collect_held_payments_for_token(
 
     Ok((total, payments))
 }
-
 
 #[contractimpl]
 impl PaymentsContract {

--- a/contracts/payments/src/lib.rs
+++ b/contracts/payments/src/lib.rs
@@ -145,7 +145,12 @@ fn create_payment(env: Env, params: PaymentParams) -> Result<u64, PaymentError> 
     );
 
     if let Some(hash) = params.email_hash {
-        events::emit_payment_receipt_requested(&env, payment_id, Some(hash));
+        events::emit_payment_receipt_requested(
+            &env,
+            payment_id,
+            params.event_id.clone(),
+            Some(hash),
+        );
     }
 
     let ticket_id = storage::get_next_ticket_id(&env);
@@ -474,6 +479,7 @@ impl PaymentsContract {
             payment.event_id.clone(),
             payment.payer,
             refund_amt,
+            payment.token.clone(),
             &storage::get_emission_privacy(&env, &payment.event_id),
         );
 
@@ -529,6 +535,7 @@ impl PaymentsContract {
                 event_id.clone(),
                 fee_amount,
                 organizer_amount,
+                payout_token.clone(),
             );
         }
 
@@ -545,8 +552,10 @@ impl PaymentsContract {
         events::emit_revenue_withdrawn(
             &env,
             event_id.clone(),
-            stored_organizer,
+            stored_organizer.clone(),
             organizer_amount,
+            payout_token,
+            stored_organizer,
             &storage::get_emission_privacy(&env, &event_id),
         );
 
@@ -687,6 +696,7 @@ impl PaymentsContract {
                 event_id.clone(),
                 fee_amount,
                 organizer_amount,
+                token_address.clone(),
             );
         }
 
@@ -711,6 +721,16 @@ impl PaymentsContract {
             organizer: to.clone(),
         };
         storage::add_withdrawal_record(&env, &event_id, &record);
+
+        events::emit_revenue_withdrawn(
+            &env,
+            event_id.clone(),
+            to.clone(),
+            organizer_amount,
+            token_address,
+            to,
+            &storage::get_emission_privacy(&env, &event_id),
+        );
 
         Ok(())
     }
@@ -737,7 +757,7 @@ impl PaymentsContract {
         storage::set_platform_fee_bps(&env, fee_bps);
         storage::set_platform_wallet(&env, &wallet);
 
-        events::emit_platform_fee_updated(&env, old_bps, fee_bps);
+        events::emit_platform_fee_updated(&env, admin, old_bps, fee_bps);
 
         Ok(())
     }
@@ -776,7 +796,13 @@ impl PaymentsContract {
 
         storage::reset_platform_revenue(&env, &event_id);
 
-        events::emit_platform_revenue_withdrawn(&env, event_id, platform_revenue, platform_wallet);
+        events::emit_platform_revenue_withdrawn(
+            &env,
+            event_id,
+            platform_revenue,
+            token_address,
+            platform_wallet,
+        );
 
         Ok(())
     }
@@ -907,8 +933,10 @@ impl PaymentsContract {
         events::emit_revenue_withdrawn(
             &env,
             event_id.clone(),
-            organizer,
+            organizer.clone(),
             total,
+            token_address,
+            organizer,
             &storage::get_emission_privacy(&env, &event_id),
         );
 
@@ -972,6 +1000,8 @@ impl PaymentsContract {
                         event_id.clone(),
                         organizer.clone(),
                         total,
+                        token_address.clone(),
+                        organizer.clone(),
                         &storage::get_emission_privacy(&env, &event_id),
                     );
                 }

--- a/contracts/payments/src/lib.rs
+++ b/contracts/payments/src/lib.rs
@@ -69,6 +69,10 @@ fn create_payment(env: Env, params: PaymentParams) -> Result<u64, PaymentError> 
     )?;
 
     if let Some(config) = storage::get_event_config(&env, &params.event_id) {
+        if config.max_supply > 0 && config.sold_count >= config.max_supply {
+            return Err(PaymentError::EventSoldOut);
+        }
+
         if config.max_tickets_per_user > 0 {
             let current_tickets =
                 storage::get_user_event_tickets(&env, &params.event_id, &params.payer);
@@ -143,6 +147,9 @@ fn create_payment(env: Env, params: PaymentParams) -> Result<u64, PaymentError> 
     storage::save_ticket(&env, &ticket)?;
     storage::add_owner_ticket(&env, &payment.payer, ticket_id);
     storage::increment_user_event_tickets(&env, &params.event_id, &params.payer);
+    if storage::get_event_config(&env, &params.event_id).is_some() {
+        storage::increment_event_sold_count(&env, &params.event_id)?;
+    }
     events::emit_ticket_issued(
         &env,
         ticket_id,
@@ -177,6 +184,7 @@ fn collect_held_payments_for_token(
 
     Ok((total, payments))
 }
+
 
 #[contractimpl]
 impl PaymentsContract {
@@ -338,6 +346,7 @@ impl PaymentsContract {
         allow_anonymous: bool,
         requires_verification: bool,
         max_tickets_per_user: u32,
+        max_supply: u32,
     ) -> Result<(), PaymentError> {
         if event_contract != storage::get_event_contract(&env)? {
             return Err(PaymentError::Unauthorized);
@@ -349,14 +358,18 @@ impl PaymentsContract {
             return Err(PaymentError::InvalidPayoutToken);
         }
 
-        if let Some(existing_config) = storage::get_event_config(&env, &event_id) {
-            if existing_config.organizer != organizer {
-                return Err(PaymentError::InvalidOrganizer);
-            }
-            if existing_config.payout_token != payout_token {
-                return Err(PaymentError::InvalidPayoutToken);
-            }
-        }
+        let existing_sold_count =
+            if let Some(existing_config) = storage::get_event_config(&env, &event_id) {
+                if existing_config.organizer != organizer {
+                    return Err(PaymentError::InvalidOrganizer);
+                }
+                if existing_config.payout_token != payout_token {
+                    return Err(PaymentError::InvalidPayoutToken);
+                }
+                existing_config.sold_count
+            } else {
+                0
+            };
 
         storage::set_event_config(
             &env,
@@ -367,6 +380,8 @@ impl PaymentsContract {
                 allow_anonymous,
                 requires_verification,
                 max_tickets_per_user,
+                max_supply,
+                sold_count: existing_sold_count,
             },
         );
 

--- a/contracts/payments/src/multi_token_test.rs
+++ b/contracts/payments/src/multi_token_test.rs
@@ -198,6 +198,7 @@ fn test_withdraw_uses_only_the_event_payout_token_revenue() {
         &true,
         &false,
         &0,
+        &0,
     );
     client.pay_for_ticket(
         &1,

--- a/contracts/payments/src/storage.rs
+++ b/contracts/payments/src/storage.rs
@@ -21,6 +21,8 @@ pub struct EventConfig {
     pub allow_anonymous: bool,
     pub requires_verification: bool,
     pub max_tickets_per_user: u32,
+    pub max_supply: u32,
+    pub sold_count: u32,
 }
 
 #[contracttype]
@@ -627,4 +629,14 @@ pub fn increment_user_event_tickets(env: &Env, event_id: &Symbol, user: &Address
     env.storage()
         .persistent()
         .extend_ttl(&key, 60 * 60 * 24 * 30, 60 * 60 * 24 * 30 * 2);
+}
+
+pub fn increment_event_sold_count(env: &Env, event_id: &Symbol) -> Result<(), PaymentError> {
+    let mut config = get_event_config(env, event_id).ok_or(PaymentError::InvalidOrganizer)?;
+    config.sold_count = config
+        .sold_count
+        .checked_add(1)
+        .ok_or(PaymentError::EventSoldOut)?;
+    set_event_config(env, event_id, &config);
+    Ok(())
 }

--- a/contracts/payments/src/storage.rs
+++ b/contracts/payments/src/storage.rs
@@ -52,6 +52,7 @@ pub enum DataKey {
     ProcessedNonce(Address, u64),
     ContractVersion,
     UserEventTickets(Symbol, Address),
+    Paused,
 }
 
 pub fn set_event_status(env: &Env, event_id: &Symbol, status: &EventStatus) {
@@ -83,6 +84,20 @@ pub fn set_admin(env: &Env, admin: &soroban_sdk::Address) {
         60 * 60 * 24 * 30,
         60 * 60 * 24 * 30 * 2,
     );
+}
+
+pub fn is_paused(env: &Env) -> bool {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Paused)
+        .unwrap_or(false)
+}
+
+pub fn set_paused(env: &Env, paused: bool) {
+    env.storage().persistent().set(&DataKey::Paused, &paused);
+    env.storage()
+        .persistent()
+        .extend_ttl(&DataKey::Paused, TTL_THRESHOLD, TTL_BUMP);
 }
 
 /// Get the accepted token address from storage.

--- a/contracts/payments/src/test.rs
+++ b/contracts/payments/src/test.rs
@@ -184,6 +184,7 @@ fn bind_event(
         &true,
         &false,
         &0,
+        &0,
     );
 }
 
@@ -1559,6 +1560,7 @@ fn test_sync_event_config_invalid_payout_token_rejected() {
         &true,
         &false,
         &0,
+        &0,
     );
     assert_eq!(result.err(), Some(Ok(PaymentError::InvalidPayoutToken)));
 
@@ -1791,6 +1793,7 @@ fn test_max_tickets_per_user_enforcement() {
         &true,
         &false,
         &2,
+        &0,
     );
 
     // Payer 1: First ticket -> Success
@@ -1840,6 +1843,73 @@ fn test_max_tickets_per_user_enforcement() {
 
     assert_eq!(client.get_owner_tickets(&payer1).len(), 2);
     assert_eq!(client.get_owner_tickets(&payer2).len(), 1);
+}
+
+#[test]
+fn test_event_supply_enforcement() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (admin, token, client, _contract_id, token_contract, event_contract_id) =
+        setup_contract_with_token_and_event(&env);
+    let payer1 = Address::generate(&env);
+    let payer2 = Address::generate(&env);
+    let payer3 = Address::generate(&env);
+    let organizer = Address::generate(&env);
+    let event_id = symbol_short!("SUPPLY");
+    let amount = 100_000_000i128;
+
+    token_contract.mint(&admin, &(amount * 3));
+    let token_client = token::Client::new(&env, &token);
+    token_client.transfer(&admin, &payer1, &amount);
+    token_client.transfer(&admin, &payer2, &amount);
+    token_client.transfer(&admin, &payer3, &amount);
+
+    client.sync_event_config(
+        &event_contract_id,
+        &event_id,
+        &organizer,
+        &token,
+        &true,
+        &false,
+        &0,
+        &2,
+    );
+
+    client.pay_for_ticket(
+        &1,
+        &payer1,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Standard,
+    );
+    client.pay_for_ticket(
+        &1,
+        &payer2,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Standard,
+    );
+
+    let config = client.get_event_config(&event_id);
+    assert_eq!(config.max_supply, 2);
+    assert_eq!(config.sold_count, 2);
+
+    let result = client.try_pay_for_ticket(
+        &1,
+        &payer3,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Standard,
+    );
+    assert_eq!(result.err(), Some(Ok(PaymentError::EventSoldOut)));
+    assert_eq!(token_client.balance(&payer3), amount);
 }
 
 // ===== Platform Fee Tests =====

--- a/contracts/payments/src/test.rs
+++ b/contracts/payments/src/test.rs
@@ -87,6 +87,79 @@ fn test_get_event_revenue_initial() {
     assert_eq!(revenue, 0);
 }
 
+#[test]
+fn test_pause_unpause_and_blocks_sensitive_actions() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (admin, token, client, _contract_id, token_contract, _) = setup_contract_with_token(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EVENT1");
+    let amount = 100_000_000i128;
+
+    token_contract.mint(&admin, &amount);
+    let token_client = token::Client::new(&env, &token);
+    token_client.transfer(&admin, &payer, &amount);
+
+    assert!(!client.is_paused());
+    client.set_paused(&admin, &true);
+    assert!(client.is_paused());
+
+    let status_result = client.try_set_event_status(&admin, &event_id, &EventStatus::Active);
+    assert_eq!(status_result.err(), Some(Ok(PaymentError::ContractPaused)));
+
+    let payment_result = client.try_pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Standard,
+    );
+    assert_eq!(payment_result.err(), Some(Ok(PaymentError::ContractPaused)));
+    assert_eq!(token_client.balance(&payer), amount);
+
+    let wallet = Address::generate(&env);
+    let fee_result = client.try_set_platform_fee(&250, &wallet);
+    assert_eq!(fee_result.err(), Some(Ok(PaymentError::ContractPaused)));
+
+    client.set_paused(&admin, &false);
+    assert!(!client.is_paused());
+    set_event_status_for_test(&client, &admin, &event_id, &EventStatus::Active);
+
+    let payment_id = client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Standard,
+    );
+
+    client.set_paused(&admin, &true);
+    let refund_result = client.try_refund(&admin, &payment_id, &None);
+    assert_eq!(refund_result.err(), Some(Ok(PaymentError::ContractPaused)));
+    assert_eq!(client.get_payment(&payment_id).status, PaymentStatus::Held);
+}
+
+#[test]
+fn test_pause_requires_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (admin, _token, client, _contract_id, _token_contract, _) = setup_contract_with_token(&env);
+    let not_admin = Address::generate(&env);
+
+    let result = client.try_set_paused(&not_admin, &true);
+    assert_eq!(result.err(), Some(Ok(PaymentError::Unauthorized)));
+    assert!(!client.is_paused());
+
+    client.set_paused(&admin, &true);
+    assert!(client.is_paused());
+}
+
 fn setup_contract_with_token(
     env: &Env,
 ) -> (

--- a/contracts/payments/src/test.rs
+++ b/contracts/payments/src/test.rs
@@ -2232,10 +2232,12 @@ fn test_replay_attack_rejected_detailed() {
         &PaymentPrivacy::Standard,
     );
     assert_eq!(result.err(), Some(Ok(PaymentError::DuplicateRequest)));
+    assert_eq!(client.get_owner_tickets(&payer).len(), 1);
+    assert_eq!(token_client.balance(&payer), amount);
 }
 
 #[test]
-fn test_optional_nonce_success() {
+fn test_zero_nonce_rejected() {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -2250,10 +2252,9 @@ fn test_optional_nonce_success() {
 
     set_event_status_for_test(&client, &admin, &event_id, &EventStatus::Active);
 
-    let nonce = 0u64; // Optional nonce
+    let nonce = 0u64;
 
-    // First attempt succeeds
-    client.pay_for_ticket(
+    let result = client.try_pay_for_ticket(
         &nonce,
         &payer,
         &event_id,
@@ -2262,20 +2263,10 @@ fn test_optional_nonce_success() {
         &token,
         &PaymentPrivacy::Standard,
     );
+    assert_eq!(result.err(), Some(Ok(PaymentError::NonceRequired)));
 
-    // Second attempt with nonce 0 also succeeds (skip deduplication)
-    client.pay_for_ticket(
-        &nonce,
-        &payer,
-        &event_id,
-        &amount,
-        &None,
-        &token,
-        &PaymentPrivacy::Standard,
-    );
-
-    let owner_tickets = client.get_owner_tickets(&payer);
-    assert_eq!(owner_tickets.len(), 2);
+    assert_eq!(client.get_owner_tickets(&payer).len(), 0);
+    assert_eq!(token_client.balance(&payer), amount * 2);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This PR hardens the ticketing/payment flow at the contract level and improves operational/indexing support.

### Added
- Contract-level event supply tracking with `max_supply` and `sold_count`
- Supply enforcement before accepting payments/registrations
- Payment replay protection with required non-zero nonces
- Admin-controlled contract pause / emergency stop
- Indexer-friendly standardized payment events with consistent IDs, timestamps, event types, token context, and actor/recipient data

### Changed
- Synced event supply metadata into the payments contract config
- Incremented sold counters only after successful payment/ticket issuance
- Rejected duplicate payment requests using stored `(payer, nonce)` keys
- Rejected zero nonce payments with `NonceRequired`
- Guarded sensitive payment contract actions when paused
- Standardized emitted payment-domain event payloads for easier indexing

### Tests
- Buy until sold out, then reject the next purchase
- Verify accurate sold tracking
- Duplicate payment request fails without double charging or minting
- Zero nonce payment is rejected
- Admin can pause/unpause contract
- Non-admin cannot pause contract
- Paused contract blocks sensitive actions
- Full workspace test suite passes

## Verification

```bash
cargo fmt
cargo test -p payments-contract
cargo test
```

## Related Issues
Closes #99 
Closes #101
Closes #103 
Closes #105 