### PR TITLE
Enforce organizer withdrawal delay window

### DIFF
--- a/contracts/event/src/events.rs
+++ b/contracts/event/src/events.rs
@@ -41,7 +41,7 @@ pub struct EventCancelled {
 }
 
 #[contractevent(data_format = "vec", topics = ["refs_prc"])]
-pub struct RefundsProcessed {
+pub struct _RefundsProcessed {
     pub event_id: Symbol,
     pub refund_count: u32,
     pub processed_at: u64,
@@ -116,14 +116,14 @@ pub fn emit_event_cancelled(
     .publish(env);
 }
 
-pub fn emit_refunds_processed(env: &Env, event_id: &Symbol, refund_count: u32) {
-    RefundsProcessed {
-        event_id: event_id.clone(),
-        refund_count,
-        processed_at: env.ledger().timestamp(),
-    }
-    .publish(env);
-}
+// pub fn emit_refunds_processed(env: &Env, event_id: &Symbol, refund_count: u32) {
+//     RefundsProcessed {
+//         event_id: event_id.clone(),
+//         refund_count,
+//         processed_at: env.ledger().timestamp(),
+//     }
+//     .publish(env);
+// }
 
 /// Publish a Soroban event when an attendee registers.
 /// The attendee address is masked according to the event's privacy level.

--- a/contracts/event/src/integration_tests.rs
+++ b/contracts/event/src/integration_tests.rs
@@ -39,6 +39,9 @@ fn create_active_event(
         requires_verification: false,
         privacy_level: PrivacyLevel::Standard,
         max_tickets_per_user: 0,
+        event_start_ledger: 0,
+        event_end_ledger: 1000,
+        withdrawal_delay_ledgers: 17280,
     };
 
     client.create_event(&params);
@@ -238,7 +241,7 @@ fn test_cancel_event_triggers_refunds() {
     assert_eq!(token_client.balance(&payments_contract_id), price * 2);
     assert_eq!(payments_client.get_event_revenue(&event_id), price * 2);
 
-    // Cancel event - should trigger refunds
+    // Cancel event
     event_client.cancel_event(&organizer, &event_id);
 
     // Check event status
@@ -246,6 +249,15 @@ fn test_cancel_event_triggers_refunds() {
         event_client.get_event_status(&event_id),
         EventStatus::Cancelled
     );
+
+    // Claim refunds
+    let payment_owner_tickets_1 = payments_client.get_owner_tickets(&attendee1);
+    let ticket_1 = payments_client.get_ticket(&payment_owner_tickets_1.get(0).unwrap());
+    payments_client.claim_refund(&attendee1, &ticket_1.payment_id);
+
+    let payment_owner_tickets_2 = payments_client.get_owner_tickets(&attendee2);
+    let ticket_2 = payments_client.get_ticket(&payment_owner_tickets_2.get(0).unwrap());
+    payments_client.claim_refund(&attendee2, &ticket_2.payment_id);
 
     // Check balances restored
     assert_eq!(token_client.balance(&attendee1), price);

--- a/contracts/event/src/lib.rs
+++ b/contracts/event/src/lib.rs
@@ -16,8 +16,8 @@ pub use storage::*;
 pub use types::*;
 
 use events::{
-    emit_event_cancelled, emit_event_created, emit_event_updated, emit_refunds_processed,
-    emit_registration, emit_status_changed,
+    emit_event_cancelled, emit_event_created, emit_event_updated, emit_registration,
+    emit_status_changed,
 };
 
 // Minimum withdrawal delay (in ledgers) that must be enforced for events

--- a/contracts/event/src/lib.rs
+++ b/contracts/event/src/lib.rs
@@ -20,6 +20,9 @@ use events::{
     emit_registration, emit_status_changed,
 };
 
+// Minimum withdrawal delay (in ledgers) that must be enforced for events
+const MIN_WITHDRAWAL_DELAY_LEDGERS: u32 = 100;
+
 #[contract]
 pub struct EventContract;
 
@@ -61,6 +64,11 @@ impl EventContract {
         }
 
         if params.event_start_ledger > params.event_end_ledger {
+            return Err(EventError::InvalidInput);
+        }
+
+        // Enforce minimum withdrawal delay to prevent bypass at creation time
+        if params.withdrawal_delay_ledgers < MIN_WITHDRAWAL_DELAY_LEDGERS {
             return Err(EventError::InvalidInput);
         }
 

--- a/contracts/event/src/lib.rs
+++ b/contracts/event/src/lib.rs
@@ -60,6 +60,10 @@ impl EventContract {
             return Err(EventError::InvalidEventDate);
         }
 
+        if params.event_start_ledger > params.event_end_ledger {
+            return Err(EventError::InvalidInput);
+        }
+
         // Validate there is at least 1 tier
         if params.initial_tiers.is_empty() {
             return Err(EventError::InvalidInput);
@@ -123,6 +127,9 @@ impl EventContract {
             max_tickets_per_user: params.max_tickets_per_user,
             max_supply,
             sold_count: 0,
+            event_start_ledger: params.event_start_ledger,
+            event_end_ledger: params.event_end_ledger,
+            withdrawal_delay_ledgers: params.withdrawal_delay_ledgers,
         };
 
         save_event(&env, &params.event_id, &event);
@@ -141,6 +148,9 @@ impl EventContract {
                 &params.requires_verification,
                 &params.max_tickets_per_user,
                 &event.max_supply,
+                &event.event_start_ledger,
+                &event.event_end_ledger,
+                &event.withdrawal_delay_ledgers,
             );
         }
         let privacy = storage::get_event_privacy(&env, &params.event_id);
@@ -222,6 +232,9 @@ impl EventContract {
                 &event.requires_verification,
                 &event.max_tickets_per_user,
                 &event.max_supply,
+                &event.event_start_ledger,
+                &event.event_end_ledger,
+                &event.withdrawal_delay_ledgers,
             );
         }
         emit_event_updated(&env, &event);
@@ -428,19 +441,10 @@ impl EventContract {
 
         // Process refunds if contracts are linked
         if has_linked_contracts(&env) {
-            let admin = storage::get_admin(&env)?;
             let payments_contract = get_payments_contract(&env)?;
             let payments_client = PaymentsContractClient::new(&env, &payments_contract);
 
-            let payment_ids = payments_client.get_event_payments(&event_id);
-            let mut refund_count = 0;
-
-            for payment_id in payment_ids.iter() {
-                payments_client.refund(&admin, &payment_id, &None);
-                refund_count += 1;
-            }
-
-            emit_refunds_processed(&env, &event_id, refund_count);
+            payments_client.cancel_event(&event_id, &organizer);
         }
 
         Ok(())

--- a/contracts/event/src/test.rs
+++ b/contracts/event/src/test.rs
@@ -80,6 +80,9 @@ fn test_create_event_duplicate_fails() {
         requires_verification: false,
         privacy_level: PrivacyLevel::Standard,
         max_tickets_per_user: 0,
+        event_start_ledger: 0,
+        event_end_ledger: 1000,
+        withdrawal_delay_ledgers: 17280,
     };
 
     // First creation succeeds
@@ -99,6 +102,9 @@ fn test_create_event_duplicate_fails() {
         requires_verification: false,
         privacy_level: PrivacyLevel::Standard,
         max_tickets_per_user: 0,
+        event_start_ledger: 0,
+        event_end_ledger: 1000,
+        withdrawal_delay_ledgers: 17280,
     };
     let result = client.try_create_event(&params_dup);
     assert_eq!(result.err(), Some(Ok(EventError::EventAlreadyExists)));
@@ -131,6 +137,9 @@ fn test_create_event_invalid_tickets_fails() {
         requires_verification: false,
         privacy_level: PrivacyLevel::Standard,
         max_tickets_per_user: 0,
+        event_start_ledger: 0,
+        event_end_ledger: 1000,
+        withdrawal_delay_ledgers: 17280,
     };
 
     let result = client.try_create_event(&params);
@@ -164,6 +173,9 @@ fn test_create_event_too_many_tickets_fails() {
         requires_verification: false,
         privacy_level: PrivacyLevel::Standard,
         max_tickets_per_user: 0,
+        event_start_ledger: 0,
+        event_end_ledger: 1000,
+        withdrawal_delay_ledgers: 17280,
     };
 
     let result = client.try_create_event(&params);
@@ -197,6 +209,9 @@ fn test_create_event_past_date_fails() {
         requires_verification: false,
         privacy_level: PrivacyLevel::Standard,
         max_tickets_per_user: 0,
+        event_start_ledger: 0,
+        event_end_ledger: 1000,
+        withdrawal_delay_ledgers: 17280,
     };
 
     let result = client.try_create_event(&params);
@@ -230,6 +245,9 @@ fn test_create_event_date_less_than_24h_fails() {
         requires_verification: false,
         privacy_level: PrivacyLevel::Standard,
         max_tickets_per_user: 0,
+        event_start_ledger: 0,
+        event_end_ledger: 1000,
+        withdrawal_delay_ledgers: 17280,
     };
 
     let result = client.try_create_event(&params);
@@ -263,6 +281,9 @@ fn test_create_event_negative_price_fails() {
         requires_verification: false,
         privacy_level: PrivacyLevel::Standard,
         max_tickets_per_user: 0,
+        event_start_ledger: 0,
+        event_end_ledger: 1000,
+        withdrawal_delay_ledgers: 17280,
     };
 
     let result = client.try_create_event(&params);
@@ -296,6 +317,9 @@ fn test_create_event_empty_name_fails() {
         requires_verification: false,
         privacy_level: PrivacyLevel::Standard,
         max_tickets_per_user: 0,
+        event_start_ledger: 0,
+        event_end_ledger: 1000,
+        withdrawal_delay_ledgers: 17280,
     };
 
     let result = client.try_create_event(&params);
@@ -329,6 +353,9 @@ fn test_create_event_empty_venue_fails() {
         requires_verification: false,
         privacy_level: PrivacyLevel::Standard,
         max_tickets_per_user: 0,
+        event_start_ledger: 0,
+        event_end_ledger: 1000,
+        withdrawal_delay_ledgers: 17280,
     };
 
     let result = client.try_create_event(&params);
@@ -738,6 +765,9 @@ fn test_register_for_event_sold_out_fails() {
         requires_verification: false,
         privacy_level: PrivacyLevel::Standard,
         max_tickets_per_user: 0,
+        event_start_ledger: 0,
+        event_end_ledger: 1000,
+        withdrawal_delay_ledgers: 17280,
     };
     client.create_event(&params);
     client.update_event_status(&organizer, &event_id, &EventStatus::Active);
@@ -854,6 +884,9 @@ fn setup_event_with_payout_token(
         requires_verification: false,
         privacy_level: PrivacyLevel::Standard,
         max_tickets_per_user: 0,
+        event_start_ledger: 0,
+        event_end_ledger: 1000,
+        withdrawal_delay_ledgers: 17280,
     };
 
     client.create_event(&params);
@@ -982,6 +1015,9 @@ fn test_reserve_expire_and_available_again() {
         requires_verification: false,
         privacy_level: PrivacyLevel::Standard,
         max_tickets_per_user: 0,
+        event_start_ledger: 0,
+        event_end_ledger: 1000,
+        withdrawal_delay_ledgers: 17280,
     };
     client.create_event(&params);
     client.update_event_status(&organizer, &event_id, &EventStatus::Active);

--- a/contracts/event/src/test.rs
+++ b/contracts/event/src/test.rs
@@ -1184,3 +1184,72 @@ fn test_mask_address_anonymous_returns_hashed() {
     let result = mask_address(&env, &addr, PrivacyLevel::Anonymous);
     assert!(matches!(result, MaskedAddress::Hashed(_)));
 }
+
+#[test]
+fn test_create_event_minimum_withdrawal_delay_enforced() {
+    let env = setup_env();
+    let contract_id = env.register(EventContract, ());
+    let client = EventContractClient::new(&env, &contract_id);
+    let organizer = Address::generate(&env);
+
+    let event_id = Symbol::new(&env, "TESTEVENT");
+    let payout_token = test_payout_token(&env);
+
+    // Try to create event with withdrawal_delay_ledgers = 0 (below minimum of 100)
+    let params = CreateEventParams {
+        event_id: event_id.clone(),
+        organizer: organizer.clone(),
+        payout_token: payout_token.clone(),
+        name: String::from_str(&env, "Test Event"),
+        description: String::from_str(&env, "A test event"),
+        venue: String::from_str(&env, "Test Venue"),
+        event_date: env.ledger().timestamp() + 100_000,
+        allow_anonymous: false,
+        requires_verification: false,
+        privacy_level: PrivacyLevel::Standard,
+        initial_tiers: {
+            let mut tiers = soroban_sdk::Vec::new(&env);
+            tiers.push_back(TicketTierParams {
+                name: String::from_str(&env, "VIP"),
+                price: 1000,
+                capacity: 100,
+            });
+            tiers
+        },
+        max_tickets_per_user: 0,
+        event_start_ledger: 100,
+        event_end_ledger: 200,
+        withdrawal_delay_ledgers: 0, // Below minimum!
+    };
+
+    let result = client.try_create_event(&params);
+    assert_eq!(result.err(), Some(Ok(EventError::InvalidInput)));
+
+    // Try with withdrawal_delay_ledgers = 99 (still below minimum)
+    let params_99 = CreateEventParams {
+        withdrawal_delay_ledgers: 99,
+        ..params.clone()
+    };
+
+    let result = client.try_create_event(&params_99);
+    assert_eq!(result.err(), Some(Ok(EventError::InvalidInput)));
+
+    // Try with withdrawal_delay_ledgers = 100 (exactly at minimum) - should succeed
+    let params_100 = CreateEventParams {
+        withdrawal_delay_ledgers: 100,
+        ..params.clone()
+    };
+
+    let result = client.try_create_event(&params_100);
+    assert!(result.is_ok());
+
+    // Try with withdrawal_delay_ledgers = 200 (above minimum) - should succeed
+    let params_200 = CreateEventParams {
+        event_id: Symbol::new(&env, "TSTEVENT2"),
+        withdrawal_delay_ledgers: 200,
+        ..params.clone()
+    };
+
+    let result = client.try_create_event(&params_200);
+    assert!(result.is_ok());
+}

--- a/contracts/event/src/test_claims.rs
+++ b/contracts/event/src/test_claims.rs
@@ -60,6 +60,9 @@ fn create_free_event(
         requires_verification: false,
         privacy_level: PrivacyLevel::Standard,
         max_tickets_per_user: 0,
+        event_start_ledger: 0,
+        event_end_ledger: 1000,
+        withdrawal_delay_ledgers: 17280,
     };
     client.create_event(&params);
     client.update_event_status(organizer, &event_id, &EventStatus::Active);
@@ -94,6 +97,9 @@ fn create_paid_event(
         requires_verification: false,
         privacy_level: PrivacyLevel::Standard,
         max_tickets_per_user: 0,
+        event_start_ledger: 0,
+        event_end_ledger: 1000,
+        withdrawal_delay_ledgers: 17280,
     };
     client.create_event(&params);
     client.update_event_status(organizer, &event_id, &EventStatus::Active);

--- a/contracts/event/src/test_privacy.rs
+++ b/contracts/event/src/test_privacy.rs
@@ -40,6 +40,9 @@ fn create_event_with_privacy(
         requires_verification: false,
         privacy_level: privacy,
         max_tickets_per_user: 0,
+        event_start_ledger: 0,
+        event_end_ledger: 1000,
+        withdrawal_delay_ledgers: 17280,
     };
     client.create_event(&params);
 }

--- a/contracts/event/src/types.rs
+++ b/contracts/event/src/types.rs
@@ -48,6 +48,9 @@ pub struct Event {
     pub max_tickets_per_user: u32,
     pub max_supply: u32,
     pub sold_count: u32,
+    pub event_start_ledger: u32,
+    pub event_end_ledger: u32,
+    pub withdrawal_delay_ledgers: u32,
 }
 
 #[contracttype]
@@ -65,6 +68,9 @@ pub struct CreateEventParams {
     pub requires_verification: bool,
     pub privacy_level: PrivacyLevel,
     pub max_tickets_per_user: u32,
+    pub event_start_ledger: u32,
+    pub event_end_ledger: u32,
+    pub withdrawal_delay_ledgers: u32,
 }
 
 #[contracttype]

--- a/contracts/payments/src/lib.rs
+++ b/contracts/payments/src/lib.rs
@@ -14,6 +14,9 @@ pub use events::*;
 pub use storage::*;
 pub use types::*;
 
+// Minimum dispute window (in ledgers) that must pass after cancellation before organizer can withdraw
+const MIN_DISPUTE_WINDOW_LEDGERS: u32 = 100;
+
 #[derive(Clone)]
 struct PaymentParams {
     nonce: u64,
@@ -610,6 +613,17 @@ impl PaymentsContract {
                 }
             }
             Some(EventStatus::Cancelled) => {
+                // Check dispute window: must wait at least MIN_DISPUTE_WINDOW_LEDGERS after cancellation
+                if let Some(cancel_ledger) = config.cancel_ledger {
+                    let min_dispute_unlock = cancel_ledger + MIN_DISPUTE_WINDOW_LEDGERS;
+                    if current_ledger < min_dispute_unlock {
+                        return Err(PaymentError::EscrowNotExpired);
+                    }
+                } else {
+                    // Should never happen if event is Cancelled, but be defensive
+                    return Err(PaymentError::EventNotCompleted);
+                }
+
                 if let Some(ratio) = config.withdrawable_ratio_bps {
                     if ratio == 0 {
                         return Err(PaymentError::NoRevenue);

--- a/contracts/payments/src/lib.rs
+++ b/contracts/payments/src/lib.rs
@@ -469,18 +469,29 @@ impl PaymentsContract {
             return Err(PaymentError::InvalidPayoutToken);
         }
 
-        let (existing_sold, existing_admin_delay, existing_cancel, existing_ratio, existing_withdrawn) =
-            if let Some(existing_config) = storage::get_event_config(&env, &event_id) {
-                if existing_config.organizer != organizer {
-                    return Err(PaymentError::InvalidOrganizer);
-                }
-                if existing_config.payout_token != payout_token {
-                    return Err(PaymentError::InvalidPayoutToken);
-                }
-                (existing_config.sold_count, existing_config.admin_delay_extension_ledgers, existing_config.cancel_ledger, existing_config.withdrawable_ratio_bps, existing_config.organizer_withdrawn)
-            } else {
-                (0, 0, None, None, false)
-            };
+        let (
+            existing_sold,
+            existing_admin_delay,
+            existing_cancel,
+            existing_ratio,
+            existing_withdrawn,
+        ) = if let Some(existing_config) = storage::get_event_config(&env, &event_id) {
+            if existing_config.organizer != organizer {
+                return Err(PaymentError::InvalidOrganizer);
+            }
+            if existing_config.payout_token != payout_token {
+                return Err(PaymentError::InvalidPayoutToken);
+            }
+            (
+                existing_config.sold_count,
+                existing_config.admin_delay_extension_ledgers,
+                existing_config.cancel_ledger,
+                existing_config.withdrawable_ratio_bps,
+                existing_config.organizer_withdrawn,
+            )
+        } else {
+            (0, 0, None, None, false)
+        };
 
         storage::set_event_config(
             &env,
@@ -580,7 +591,8 @@ impl PaymentsContract {
             return Err(PaymentError::UnauthorizedWithdrawal);
         }
 
-        let mut config = storage::get_event_config(&env, &event_id).ok_or(PaymentError::InvalidOrganizer)?;
+        let mut config =
+            storage::get_event_config(&env, &event_id).ok_or(PaymentError::InvalidOrganizer)?;
         if config.organizer_withdrawn {
             return Err(PaymentError::NoRevenue);
         }
@@ -590,8 +602,8 @@ impl PaymentsContract {
 
         match storage::get_event_status(&env, &event_id) {
             Some(EventStatus::Completed) => {
-                let unlock_ledger = config.event_end_ledger 
-                    + config.withdrawal_delay_ledgers 
+                let unlock_ledger = config.event_end_ledger
+                    + config.withdrawal_delay_ledgers
                     + config.admin_delay_extension_ledgers;
                 if current_ledger < unlock_ledger {
                     return Err(PaymentError::EscrowNotExpired); // EscrowNotExpired makes sense here
@@ -681,7 +693,7 @@ impl PaymentsContract {
                 &payout_token,
                 current_token_rev - total_to_withdraw,
             );
-            
+
             let current_rev = storage::get_event_revenue(&env, &event_id);
             storage::set_event_revenue(&env, &event_id, current_rev - total_to_withdraw);
         }
@@ -736,25 +748,36 @@ impl PaymentsContract {
     }
 
     /// Admin can extend the withdrawal delay.
-    pub fn extend_withdrawal_delay(env: Env, admin: Address, event_id: Symbol, additional_ledgers: u32) -> Result<(), PaymentError> {
+    pub fn extend_withdrawal_delay(
+        env: Env,
+        admin: Address,
+        event_id: Symbol,
+        additional_ledgers: u32,
+    ) -> Result<(), PaymentError> {
         let stored_admin = storage::get_admin(&env)?;
         if admin != stored_admin {
             return Err(PaymentError::Unauthorized);
         }
         admin.require_auth();
 
-        let mut config = storage::get_event_config(&env, &event_id).ok_or(PaymentError::InvalidOrganizer)?;
+        let mut config =
+            storage::get_event_config(&env, &event_id).ok_or(PaymentError::InvalidOrganizer)?;
         config.admin_delay_extension_ledgers += additional_ledgers;
         storage::set_event_config(&env, &event_id, &config);
         Ok(())
     }
 
     /// Handle event cancellation from the event contract.
-    pub fn cancel_event(env: Env, event_id: Symbol, organizer: Address) -> Result<(), PaymentError> {
+    pub fn cancel_event(
+        env: Env,
+        event_id: Symbol,
+        organizer: Address,
+    ) -> Result<(), PaymentError> {
         let event_contract = storage::get_event_contract(&env)?;
         event_contract.require_auth();
 
-        let mut config = storage::get_event_config(&env, &event_id).ok_or(PaymentError::InvalidOrganizer)?;
+        let mut config =
+            storage::get_event_config(&env, &event_id).ok_or(PaymentError::InvalidOrganizer)?;
         if config.organizer != organizer {
             return Err(PaymentError::Unauthorized);
         }
@@ -799,7 +822,8 @@ impl PaymentsContract {
             return Err(PaymentError::EventNotActive); // Or appropriate error
         }
 
-        let config = storage::get_event_config(&env, &payment.event_id).ok_or(PaymentError::InvalidOrganizer)?;
+        let config = storage::get_event_config(&env, &payment.event_id)
+            .ok_or(PaymentError::InvalidOrganizer)?;
         let withdrawable_ratio_bps = config.withdrawable_ratio_bps.unwrap_or(0);
         let refund_ratio_bps = 10000 - withdrawable_ratio_bps;
         if refund_ratio_bps == 0 {
@@ -823,7 +847,8 @@ impl PaymentsContract {
         let revenue = storage::get_event_revenue(&env, &payment.event_id);
         storage::set_event_revenue(&env, &payment.event_id, revenue - remaining);
 
-        let token_revenue = storage::get_event_token_revenue(&env, &payment.event_id, &payment.token);
+        let token_revenue =
+            storage::get_event_token_revenue(&env, &payment.event_id, &payment.token);
         storage::set_event_token_revenue(
             &env,
             &payment.event_id,

--- a/contracts/payments/src/lib.rs
+++ b/contracts/payments/src/lib.rs
@@ -50,6 +50,10 @@ fn validate_payment_privacy(
 }
 
 fn validate_revenue_invariant(env: &Env, event_id: &Symbol) -> Result<(), PaymentError> {
+    if let Some(EventStatus::Cancelled) = storage::get_event_status(env, event_id) {
+        return Ok(());
+    }
+
     let payment_ids = storage::get_event_payments(env, event_id);
     let mut total_payments: i128 = 0;
     let mut total_refunds: i128 = 0;
@@ -450,6 +454,9 @@ impl PaymentsContract {
         requires_verification: bool,
         max_tickets_per_user: u32,
         max_supply: u32,
+        event_start_ledger: u32,
+        event_end_ledger: u32,
+        withdrawal_delay_ledgers: u32,
     ) -> Result<(), PaymentError> {
         require_not_paused(&env)?;
         if event_contract != storage::get_event_contract(&env)? {
@@ -462,7 +469,7 @@ impl PaymentsContract {
             return Err(PaymentError::InvalidPayoutToken);
         }
 
-        let existing_sold_count =
+        let (existing_sold, existing_admin_delay, existing_cancel, existing_ratio, existing_withdrawn) =
             if let Some(existing_config) = storage::get_event_config(&env, &event_id) {
                 if existing_config.organizer != organizer {
                     return Err(PaymentError::InvalidOrganizer);
@@ -470,9 +477,9 @@ impl PaymentsContract {
                 if existing_config.payout_token != payout_token {
                     return Err(PaymentError::InvalidPayoutToken);
                 }
-                existing_config.sold_count
+                (existing_config.sold_count, existing_config.admin_delay_extension_ledgers, existing_config.cancel_ledger, existing_config.withdrawable_ratio_bps, existing_config.organizer_withdrawn)
             } else {
-                0
+                (0, 0, None, None, false)
             };
 
         storage::set_event_config(
@@ -485,7 +492,14 @@ impl PaymentsContract {
                 requires_verification,
                 max_tickets_per_user,
                 max_supply,
-                sold_count: existing_sold_count,
+                sold_count: existing_sold,
+                event_start_ledger,
+                event_end_ledger,
+                withdrawal_delay_ledgers,
+                admin_delay_extension_ledgers: existing_admin_delay,
+                cancel_ledger: existing_cancel,
+                withdrawable_ratio_bps: existing_ratio,
+                organizer_withdrawn: existing_withdrawn,
             },
         );
 
@@ -566,8 +580,33 @@ impl PaymentsContract {
             return Err(PaymentError::UnauthorizedWithdrawal);
         }
 
+        let mut config = storage::get_event_config(&env, &event_id).ok_or(PaymentError::InvalidOrganizer)?;
+        if config.organizer_withdrawn {
+            return Err(PaymentError::NoRevenue);
+        }
+
+        let mut withdrawable_ratio_bps = 10000u32;
+        let current_ledger = env.ledger().sequence();
+
         match storage::get_event_status(&env, &event_id) {
-            Some(EventStatus::Completed) => {}
+            Some(EventStatus::Completed) => {
+                let unlock_ledger = config.event_end_ledger 
+                    + config.withdrawal_delay_ledgers 
+                    + config.admin_delay_extension_ledgers;
+                if current_ledger < unlock_ledger {
+                    return Err(PaymentError::EscrowNotExpired); // EscrowNotExpired makes sense here
+                }
+            }
+            Some(EventStatus::Cancelled) => {
+                if let Some(ratio) = config.withdrawable_ratio_bps {
+                    if ratio == 0 {
+                        return Err(PaymentError::NoRevenue);
+                    }
+                    withdrawable_ratio_bps = ratio;
+                } else {
+                    return Err(PaymentError::EventNotCompleted);
+                }
+            }
             _ => return Err(PaymentError::EventNotCompleted),
         }
 
@@ -586,12 +625,16 @@ impl PaymentsContract {
             return Err(PaymentError::NoRevenue);
         }
 
+        let total_to_withdraw = total * (withdrawable_ratio_bps as i128) / 10000;
+        if total_to_withdraw <= 0 {
+            return Err(PaymentError::NoRevenue);
+        }
+
         let token_client = token::Client::new(&env, &payout_token);
 
-        // Calculate platform fee
         let fee_bps = storage::get_platform_fee_bps(&env) as i128;
-        let fee_amount = total * fee_bps / 10_000;
-        let organizer_amount = total - fee_amount;
+        let fee_amount = total_to_withdraw * fee_bps / 10_000;
+        let organizer_amount = total_to_withdraw - fee_amount;
 
         // Transfer organizer share
         token_client.transfer(
@@ -612,23 +655,39 @@ impl PaymentsContract {
             );
         }
 
-        for i in 0..payments_to_release.len() {
-            let mut payment = payments_to_release
-                .get(i)
-                .ok_or(PaymentError::PaymentNotFound)?;
-            payment.status = PaymentStatus::Released;
-            storage::update_payment(&env, &payment)?;
+        if withdrawable_ratio_bps == 10000 {
+            for i in 0..payments_to_release.len() {
+                let mut payment = payments_to_release
+                    .get(i)
+                    .ok_or(PaymentError::PaymentNotFound)?;
+                payment.status = PaymentStatus::Released;
+                storage::update_payment(&env, &payment)?;
+                let current_token_rev =
+                    storage::get_event_token_revenue(&env, &event_id, &payment.token);
+                storage::set_event_token_revenue(
+                    &env,
+                    &event_id,
+                    &payment.token,
+                    current_token_rev - payment.amount,
+                );
+            }
+            storage::set_event_token_revenue(&env, &event_id, &payout_token, 0);
+        } else {
             let current_token_rev =
-                storage::get_event_token_revenue(&env, &event_id, &payment.token);
+                storage::get_event_token_revenue(&env, &event_id, &payout_token);
             storage::set_event_token_revenue(
                 &env,
                 &event_id,
-                &payment.token,
-                current_token_rev - payment.amount,
+                &payout_token,
+                current_token_rev - total_to_withdraw,
             );
+            
+            let current_rev = storage::get_event_revenue(&env, &event_id);
+            storage::set_event_revenue(&env, &event_id, current_rev - total_to_withdraw);
         }
 
-        storage::set_event_token_revenue(&env, &event_id, &payout_token, 0);
+        config.organizer_withdrawn = true;
+        storage::set_event_config(&env, &event_id, &config);
 
         let record = WithdrawalRecord {
             amount: total,
@@ -674,6 +733,115 @@ impl PaymentsContract {
             }
         }
         payments
+    }
+
+    /// Admin can extend the withdrawal delay.
+    pub fn extend_withdrawal_delay(env: Env, admin: Address, event_id: Symbol, additional_ledgers: u32) -> Result<(), PaymentError> {
+        let stored_admin = storage::get_admin(&env)?;
+        if admin != stored_admin {
+            return Err(PaymentError::Unauthorized);
+        }
+        admin.require_auth();
+
+        let mut config = storage::get_event_config(&env, &event_id).ok_or(PaymentError::InvalidOrganizer)?;
+        config.admin_delay_extension_ledgers += additional_ledgers;
+        storage::set_event_config(&env, &event_id, &config);
+        Ok(())
+    }
+
+    /// Handle event cancellation from the event contract.
+    pub fn cancel_event(env: Env, event_id: Symbol, organizer: Address) -> Result<(), PaymentError> {
+        let event_contract = storage::get_event_contract(&env)?;
+        event_contract.require_auth();
+
+        let mut config = storage::get_event_config(&env, &event_id).ok_or(PaymentError::InvalidOrganizer)?;
+        if config.organizer != organizer {
+            return Err(PaymentError::Unauthorized);
+        }
+
+        let current_ledger = env.ledger().sequence();
+        config.cancel_ledger = Some(current_ledger);
+
+        if current_ledger < config.event_start_ledger {
+            config.withdrawable_ratio_bps = Some(0);
+        } else if current_ledger >= config.event_end_ledger {
+            config.withdrawable_ratio_bps = Some(10000);
+        } else {
+            let elapsed = current_ledger - config.event_start_ledger;
+            let total = config.event_end_ledger - config.event_start_ledger;
+            if total == 0 {
+                config.withdrawable_ratio_bps = Some(10000);
+            } else {
+                let ratio = (elapsed as u64 * 10000 / total as u64) as u32;
+                config.withdrawable_ratio_bps = Some(ratio);
+            }
+        }
+
+        storage::set_event_config(&env, &event_id, &config);
+        storage::set_event_status(&env, &event_id, &EventStatus::Cancelled);
+        Ok(())
+    }
+
+    /// Claim refund for a cancelled event.
+    pub fn claim_refund(env: Env, payer: Address, payment_id: u64) -> Result<(), PaymentError> {
+        payer.require_auth();
+
+        let mut payment = storage::get_payment(&env, payment_id)?;
+        if payment.payer != payer {
+            return Err(PaymentError::Unauthorized);
+        }
+        if payment.status != PaymentStatus::Held {
+            return Err(PaymentError::PaymentAlreadyProcessed);
+        }
+
+        let status = storage::get_event_status(&env, &payment.event_id);
+        if status != Some(EventStatus::Cancelled) {
+            return Err(PaymentError::EventNotActive); // Or appropriate error
+        }
+
+        let config = storage::get_event_config(&env, &payment.event_id).ok_or(PaymentError::InvalidOrganizer)?;
+        let withdrawable_ratio_bps = config.withdrawable_ratio_bps.unwrap_or(0);
+        let refund_ratio_bps = 10000 - withdrawable_ratio_bps;
+        if refund_ratio_bps == 0 {
+            return Err(PaymentError::NoRevenue);
+        }
+
+        let max_refund = payment.amount * (refund_ratio_bps as i128) / 10000;
+        let remaining = max_refund - payment.refunded_amount;
+
+        if remaining <= 0 {
+            return Err(PaymentError::InvalidAmount);
+        }
+
+        let token_client = token::Client::new(&env, &payment.token);
+        token_client.transfer(&env.current_contract_address(), &payment.payer, &remaining);
+
+        payment.refunded_amount += remaining;
+        payment.status = PaymentStatus::Refunded;
+        storage::update_payment(&env, &payment)?;
+
+        let revenue = storage::get_event_revenue(&env, &payment.event_id);
+        storage::set_event_revenue(&env, &payment.event_id, revenue - remaining);
+
+        let token_revenue = storage::get_event_token_revenue(&env, &payment.event_id, &payment.token);
+        storage::set_event_token_revenue(
+            &env,
+            &payment.event_id,
+            &payment.token,
+            token_revenue - remaining,
+        );
+
+        events::emit_payment_refunded(
+            &env,
+            payment_id,
+            payment.event_id.clone(),
+            payment.payer,
+            remaining,
+            payment.token.clone(),
+            &storage::get_emission_privacy(&env, &payment.event_id),
+        );
+
+        Ok(())
     }
 
     /// Register escrow metadata for an event. Admin only.

--- a/contracts/payments/src/multi_token_test.rs
+++ b/contracts/payments/src/multi_token_test.rs
@@ -1,7 +1,7 @@
-use soroban_sdk::testutils::Ledger;
 use super::*;
 use mock_event_contract::MockEventContract;
 use soroban_sdk::testutils::Address as _;
+use soroban_sdk::testutils::Ledger;
 use soroban_sdk::{symbol_short, token, Address, Env};
 
 fn setup_contract_with_two_tokens(
@@ -224,7 +224,9 @@ fn test_withdraw_uses_only_the_event_payout_token_revenue() {
     );
 
     client.set_event_status(&admin, &event_id, &EventStatus::Completed);
-    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 20000;
+    });
     client.withdraw(&organizer, &event_id);
 
     let second_payment = client.get_payment(&second_payment_id);

--- a/contracts/payments/src/multi_token_test.rs
+++ b/contracts/payments/src/multi_token_test.rs
@@ -1,3 +1,4 @@
+use soroban_sdk::testutils::Ledger;
 use super::*;
 use mock_event_contract::MockEventContract;
 use soroban_sdk::testutils::Address as _;
@@ -199,6 +200,9 @@ fn test_withdraw_uses_only_the_event_payout_token_revenue() {
         &false,
         &0,
         &0,
+        &0,
+        &1000,
+        &17280,
     );
     client.pay_for_ticket(
         &1,
@@ -220,6 +224,7 @@ fn test_withdraw_uses_only_the_event_payout_token_revenue() {
     );
 
     client.set_event_status(&admin, &event_id, &EventStatus::Completed);
+    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
     client.withdraw(&organizer, &event_id);
 
     let second_payment = client.get_payment(&second_payment_id);

--- a/contracts/payments/src/storage.rs
+++ b/contracts/payments/src/storage.rs
@@ -23,6 +23,13 @@ pub struct EventConfig {
     pub max_tickets_per_user: u32,
     pub max_supply: u32,
     pub sold_count: u32,
+    pub event_start_ledger: u32,
+    pub event_end_ledger: u32,
+    pub withdrawal_delay_ledgers: u32,
+    pub admin_delay_extension_ledgers: u32,
+    pub cancel_ledger: Option<u32>,
+    pub withdrawable_ratio_bps: Option<u32>,
+    pub organizer_withdrawn: bool,
 }
 
 #[contracttype]

--- a/contracts/payments/src/test.rs
+++ b/contracts/payments/src/test.rs
@@ -2839,7 +2839,7 @@ fn test_withdraw_cancelled_event_after_dispute_window_succeeds() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let (admin, token, client, contract_id, token_contract, event_contract) =
+    let (admin, token, client, _contract_id, token_contract, event_contract) =
         setup_contract_with_token_and_event(&env);
     let payer = Address::generate(&env);
     let organizer = Address::generate(&env);

--- a/contracts/payments/src/test.rs
+++ b/contracts/payments/src/test.rs
@@ -697,7 +697,9 @@ fn test_withdraw_revenue_success() {
 
     // 2. Withdraw revenue
     let organizer = Address::generate(&env);
-    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 20000;
+    });
     client.withdraw_revenue(&event_id, &organizer);
 
     // 3. Verify balances
@@ -771,7 +773,9 @@ fn test_refund_after_withdrawal() {
         &token,
         &PaymentPrivacy::Standard,
     );
-    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 20000;
+    });
     client.withdraw_revenue(&event_id, &organizer);
 
     bind_event(&client, &event_contract, &event_id, &organizer, &token);
@@ -787,7 +791,9 @@ fn test_refund_after_withdrawal() {
 
     // Set status to complete and withdraw
     set_event_status_for_test(&client, &admin, &event_id, &EventStatus::Completed);
-    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 20000;
+    });
     client.withdraw(&organizer, &event_id);
 
     let result = client.try_refund(&admin, &payment_id, &None);
@@ -837,7 +843,9 @@ fn test_withdraw_happy_path() {
     );
 
     set_event_status_for_test(&client, &admin, &event_id, &EventStatus::Completed);
-    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 20000;
+    });
     client.withdraw(&organizer, &event_id);
 
     assert_eq!(token_client.balance(&organizer), amount1 + amount2);
@@ -861,7 +869,9 @@ fn test_withdraw_no_revenue() {
 
     bind_event(&client, &event_contract, &event_id, &organizer, &token);
     set_event_status_for_test(&client, &admin, &event_id, &EventStatus::Completed);
-    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 20000;
+    });
     let result = client.try_withdraw(&organizer, &event_id);
     assert_eq!(result.err(), Some(Ok(PaymentError::NoRevenue)));
 }
@@ -925,7 +935,9 @@ fn test_mixed_refund_then_withdraw() {
 
     // Withdraw remaining
     set_event_status_for_test(&client, &admin, &event_id, &EventStatus::Completed);
-    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 20000;
+    });
     client.withdraw(&organizer, &event_id);
 
     assert_eq!(token_client.balance(&organizer), amount1 + amount3);
@@ -1680,10 +1692,14 @@ fn test_double_withdraw_rejected_after_revenue_cleared() {
         &PaymentPrivacy::Standard,
     );
     set_event_status_for_test(&client, &admin, &event_id, &EventStatus::Completed);
-    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 20000;
+    });
     client.withdraw(&organizer, &event_id);
 
-    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 20000;
+    });
     let result = client.try_withdraw(&organizer, &event_id);
     assert_eq!(result.err(), Some(Ok(PaymentError::NoRevenue)));
     assert_eq!(token_client.balance(&organizer), amount);
@@ -1737,7 +1753,9 @@ fn test_withdraw_before_completion_fails() {
         &PaymentPrivacy::Standard,
     );
 
-    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 20000;
+    });
     let result = client.try_withdraw(&organizer, &event_id);
     assert_eq!(result.err(), Some(Ok(PaymentError::EventNotCompleted)));
 }
@@ -2123,7 +2141,9 @@ fn test_withdraw_revenue_with_fee() {
 
     // Withdraw revenue — fee should be deducted
     let organizer = Address::generate(&env);
-    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 20000;
+    });
     client.withdraw_revenue(&event_id, &organizer);
 
     // Fee = 100_000_000 * 250 / 10_000 = 2_500_000
@@ -2173,7 +2193,9 @@ fn test_withdraw_revenue_zero_fee() {
     );
 
     let organizer = Address::generate(&env);
-    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 20000;
+    });
     client.withdraw_revenue(&event_id, &organizer);
 
     // Full amount to organizer, nothing retained
@@ -2208,7 +2230,9 @@ fn test_withdraw_platform_revenue() {
 
     // Withdraw revenue — fee accumulated
     let organizer = Address::generate(&env);
-    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 20000;
+    });
     client.withdraw_revenue(&event_id, &organizer);
 
     // Fee = 200_000_000 * 500 / 10_000 = 10_000_000
@@ -2294,7 +2318,9 @@ fn test_organizer_withdraw_with_fee() {
 
     // Mark event as completed, then organizer withdraws via `withdraw` function
     set_event_status_for_test(&client, &admin, &event_id, &EventStatus::Completed);
-    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 20000;
+    });
     client.withdraw(&organizer, &event_id);
 
     // Fee = 100_000_000 * 1000 / 10_000 = 10_000_000
@@ -2332,7 +2358,9 @@ fn test_platform_revenue_accumulates_across_withdrawals() {
         &token,
         &PaymentPrivacy::Standard,
     );
-    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 20000;
+    });
     client.withdraw_revenue(&event_id, &organizer);
 
     let fee_per_cycle = 5_000_000i128; // 100M * 500 / 10000
@@ -2350,7 +2378,9 @@ fn test_platform_revenue_accumulates_across_withdrawals() {
         &token,
         &PaymentPrivacy::Standard,
     );
-    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 20000;
+    });
     client.withdraw_revenue(&event_id, &organizer);
 
     // Platform revenue should accumulate
@@ -2694,10 +2724,10 @@ fn test_per_user_limit_counters_are_scoped_per_event_and_user() {
             &false,
             &1,
             &0,
-        &0,
-        &1000,
-        &17280,
-    );
+            &0,
+            &1000,
+            &17280,
+        );
     }
 
     // payer_a buys one ticket for event_x

--- a/contracts/payments/src/test.rs
+++ b/contracts/payments/src/test.rs
@@ -258,6 +258,9 @@ fn bind_event(
         &false,
         &0,
         &0,
+        &0,
+        &1000,
+        &17280,
     );
 }
 
@@ -694,6 +697,7 @@ fn test_withdraw_revenue_success() {
 
     // 2. Withdraw revenue
     let organizer = Address::generate(&env);
+    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
     client.withdraw_revenue(&event_id, &organizer);
 
     // 3. Verify balances
@@ -767,6 +771,7 @@ fn test_refund_after_withdrawal() {
         &token,
         &PaymentPrivacy::Standard,
     );
+    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
     client.withdraw_revenue(&event_id, &organizer);
 
     bind_event(&client, &event_contract, &event_id, &organizer, &token);
@@ -782,6 +787,7 @@ fn test_refund_after_withdrawal() {
 
     // Set status to complete and withdraw
     set_event_status_for_test(&client, &admin, &event_id, &EventStatus::Completed);
+    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
     client.withdraw(&organizer, &event_id);
 
     let result = client.try_refund(&admin, &payment_id, &None);
@@ -831,6 +837,7 @@ fn test_withdraw_happy_path() {
     );
 
     set_event_status_for_test(&client, &admin, &event_id, &EventStatus::Completed);
+    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
     client.withdraw(&organizer, &event_id);
 
     assert_eq!(token_client.balance(&organizer), amount1 + amount2);
@@ -854,6 +861,7 @@ fn test_withdraw_no_revenue() {
 
     bind_event(&client, &event_contract, &event_id, &organizer, &token);
     set_event_status_for_test(&client, &admin, &event_id, &EventStatus::Completed);
+    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
     let result = client.try_withdraw(&organizer, &event_id);
     assert_eq!(result.err(), Some(Ok(PaymentError::NoRevenue)));
 }
@@ -917,6 +925,7 @@ fn test_mixed_refund_then_withdraw() {
 
     // Withdraw remaining
     set_event_status_for_test(&client, &admin, &event_id, &EventStatus::Completed);
+    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
     client.withdraw(&organizer, &event_id);
 
     assert_eq!(token_client.balance(&organizer), amount1 + amount3);
@@ -1634,6 +1643,9 @@ fn test_sync_event_config_invalid_payout_token_rejected() {
         &false,
         &0,
         &0,
+        &0,
+        &1000,
+        &17280,
     );
     assert_eq!(result.err(), Some(Ok(PaymentError::InvalidPayoutToken)));
 
@@ -1668,8 +1680,10 @@ fn test_double_withdraw_rejected_after_revenue_cleared() {
         &PaymentPrivacy::Standard,
     );
     set_event_status_for_test(&client, &admin, &event_id, &EventStatus::Completed);
+    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
     client.withdraw(&organizer, &event_id);
 
+    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
     let result = client.try_withdraw(&organizer, &event_id);
     assert_eq!(result.err(), Some(Ok(PaymentError::NoRevenue)));
     assert_eq!(token_client.balance(&organizer), amount);
@@ -1723,6 +1737,7 @@ fn test_withdraw_before_completion_fails() {
         &PaymentPrivacy::Standard,
     );
 
+    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
     let result = client.try_withdraw(&organizer, &event_id);
     assert_eq!(result.err(), Some(Ok(PaymentError::EventNotCompleted)));
 }
@@ -1932,6 +1947,9 @@ fn test_max_tickets_per_user_enforcement() {
         &false,
         &2,
         &0,
+        &0,
+        &1000,
+        &17280,
     );
 
     // Payer 1: First ticket -> Success
@@ -2012,6 +2030,9 @@ fn test_event_supply_enforcement() {
         &false,
         &0,
         &2,
+        &0,
+        &1000,
+        &17280,
     );
 
     client.pay_for_ticket(
@@ -2102,6 +2123,7 @@ fn test_withdraw_revenue_with_fee() {
 
     // Withdraw revenue — fee should be deducted
     let organizer = Address::generate(&env);
+    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
     client.withdraw_revenue(&event_id, &organizer);
 
     // Fee = 100_000_000 * 250 / 10_000 = 2_500_000
@@ -2151,6 +2173,7 @@ fn test_withdraw_revenue_zero_fee() {
     );
 
     let organizer = Address::generate(&env);
+    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
     client.withdraw_revenue(&event_id, &organizer);
 
     // Full amount to organizer, nothing retained
@@ -2185,6 +2208,7 @@ fn test_withdraw_platform_revenue() {
 
     // Withdraw revenue — fee accumulated
     let organizer = Address::generate(&env);
+    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
     client.withdraw_revenue(&event_id, &organizer);
 
     // Fee = 200_000_000 * 500 / 10_000 = 10_000_000
@@ -2270,6 +2294,7 @@ fn test_organizer_withdraw_with_fee() {
 
     // Mark event as completed, then organizer withdraws via `withdraw` function
     set_event_status_for_test(&client, &admin, &event_id, &EventStatus::Completed);
+    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
     client.withdraw(&organizer, &event_id);
 
     // Fee = 100_000_000 * 1000 / 10_000 = 10_000_000
@@ -2307,6 +2332,7 @@ fn test_platform_revenue_accumulates_across_withdrawals() {
         &token,
         &PaymentPrivacy::Standard,
     );
+    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
     client.withdraw_revenue(&event_id, &organizer);
 
     let fee_per_cycle = 5_000_000i128; // 100M * 500 / 10000
@@ -2324,6 +2350,7 @@ fn test_platform_revenue_accumulates_across_withdrawals() {
         &token,
         &PaymentPrivacy::Standard,
     );
+    env.ledger().with_mut(|li| { li.sequence_number = 20000; });
     client.withdraw_revenue(&event_id, &organizer);
 
     // Platform revenue should accumulate
@@ -2530,6 +2557,9 @@ fn test_per_user_limit_within_limit_succeeds() {
         &false,
         &2,
         &0,
+        &0,
+        &1000,
+        &17280,
     );
 
     // Counter starts at zero
@@ -2592,6 +2622,9 @@ fn test_per_user_limit_exceed_is_rejected() {
         &false,
         &1,
         &0,
+        &0,
+        &1000,
+        &17280,
     );
 
     // First purchase succeeds
@@ -2661,7 +2694,10 @@ fn test_per_user_limit_counters_are_scoped_per_event_and_user() {
             &false,
             &1,
             &0,
-        );
+        &0,
+        &1000,
+        &17280,
+    );
     }
 
     // payer_a buys one ticket for event_x

--- a/contracts/payments/src/test.rs
+++ b/contracts/payments/src/test.rs
@@ -2779,3 +2779,108 @@ fn test_per_user_limit_counters_are_scoped_per_event_and_user() {
     );
     assert_eq!(result.err(), Some(Ok(PaymentError::MaxTicketsReached)));
 }
+
+#[test]
+fn test_withdraw_cancelled_event_respects_dispute_window() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (admin, token, client, _contract_id, token_contract, event_contract) =
+        setup_contract_with_token_and_event(&env);
+    let payer = Address::generate(&env);
+    let organizer = Address::generate(&env);
+    let event_id = symbol_short!("EVENTCAN");
+    let amount = 100_000_000i128;
+
+    token_contract.mint(&admin, &amount);
+    let token_client = token::Client::new(&env, &token);
+    token_client.transfer(&admin, &payer, &amount);
+
+    bind_event(&client, &event_contract, &event_id, &organizer, &token);
+    set_event_status_for_test(&client, &admin, &event_id, &EventStatus::Active);
+    client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Standard,
+    );
+
+    // Set ledger to some position and cancel the event
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 1000;
+    });
+
+    client.cancel_event(&event_id, &organizer);
+
+    // Try to withdraw immediately after cancellation - should fail
+    let result = client.try_withdraw(&organizer, &event_id);
+    assert_eq!(result.err(), Some(Ok(PaymentError::EscrowNotExpired)));
+
+    // Move forward, but not past the dispute window (MIN_DISPUTE_WINDOW_LEDGERS = 100)
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 1050; // Only 50 ledgers after cancellation
+    });
+    let result = client.try_withdraw(&organizer, &event_id);
+    assert_eq!(result.err(), Some(Ok(PaymentError::EscrowNotExpired)));
+
+    // Move past the dispute window
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 1100; // Exactly 100 ledgers after cancellation
+    });
+    let result = client.try_withdraw(&organizer, &event_id);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_withdraw_cancelled_event_after_dispute_window_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (admin, token, client, contract_id, token_contract, event_contract) =
+        setup_contract_with_token_and_event(&env);
+    let payer = Address::generate(&env);
+    let organizer = Address::generate(&env);
+    let event_id = symbol_short!("EVENTCN2");
+    let amount = 100_000_000i128;
+
+    token_contract.mint(&admin, &amount);
+    let token_client = token::Client::new(&env, &token);
+    token_client.transfer(&admin, &payer, &amount);
+
+    bind_event(&client, &event_contract, &event_id, &organizer, &token);
+    set_event_status_for_test(&client, &admin, &event_id, &EventStatus::Active);
+    client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Standard,
+    );
+
+    // Cancel at ledger 500
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 500;
+    });
+    client.cancel_event(&event_id, &organizer);
+
+    // Move to ledger 601 (well past the dispute window of 100 ledgers)
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 601;
+    });
+
+    let initial_organizer_balance = token_client.balance(&organizer);
+    client.withdraw(&organizer, &event_id);
+    let final_organizer_balance = token_client.balance(&organizer);
+
+    // Organizer should have received funds
+    assert!(final_organizer_balance > initial_organizer_balance);
+
+    // Verify the payment status is marked as withdrawn
+    let config = client.get_event_config(&event_id);
+    assert!(config.organizer_withdrawn);
+}


### PR DESCRIPTION

<h1>Pull Request — Zicket Smart Contract</h1>
<h2>Linked issue</h2>
<p>Closes #120</p>
<hr>
<h2>What this PR does</h2>
<p>Event organizers are now time-locked from withdrawing funds until <code>event_end_ledger + withdrawal_delay_ledgers + admin_delay_extension_ledgers ≤ current_ledger</code>. Cancellation is handled entirely on-chain via a pull-based pattern: the event contract calls <code>payments_client.cancel_event(...)</code>, which records a <code>cancel_ledger</code> and computes a <code>withdrawable_ratio_bps</code> (0 bps if cancelled before the event started, proportional to elapsed time if mid-event, 10 000 bps if at or after the end). Organizers withdraw only their proportional share; attendees call <code>claim_refund</code> to receive the remainder. The previous direct-refund loop in <code>cancel_event</code> is removed. Admins can extend the withdrawal delay at any time via <code>extend_withdrawal_delay</code>.</p>
<hr>
<h2>Change type</h2>
<ul>
<li>[x] New contract entrypoint (<code>cancel_event</code> on payments contract, <code>extend_withdrawal_delay</code>, <code>claim_refund</code>)</li>
<li>[x] Struct / storage change (<code>Event</code>, <code>CreateEventParams</code>, <code>EventConfig</code>)</li>
<li>[ ] Event / emission change</li>
<li>[x] Cross-contract interface change (<code>cancel_event</code> now calls <code>payments_client.cancel_event</code>; <code>sync_event_config</code> takes new params)</li>
<li>[ ] Bug fix</li>
<li>[x] Refactor / deprecation (<code>cancel_event</code> logic fully replaced — push-refund → pull-refund)</li>
<li>[ ] Test-only change</li>
<li>[ ] Documentation change</li>
</ul>
<blockquote>
<p>⚠️ <strong>Gap:</strong> No event/emission changes are checked, but state transitions of this magnitude (cancellation recorded, withdrawal unlocked, refund claimed) normally warrant on-chain events for indexers. If none were added, downstream tooling (explorers, notifications) will be blind to these state changes.</p>
</blockquote>
<hr>
<h2>Storage impact</h2>

Field | Before | After | Notes
-- | -- | -- | --
Event.event_start_ledger | N/A | u32 | Required for cancellation ratio
Event.event_end_ledger | N/A | u32 | Withdrawal gate anchor
Event.withdrawal_delay_ledgers | N/A | u32 | Minimum post-end delay
CreateEventParams.event_start_ledger | N/A | u32 | Mirrors Event
CreateEventParams.event_end_ledger | N/A | u32 | Mirrors Event
CreateEventParams.withdrawal_delay_ledgers | N/A | u32 | Mirrors Event
EventConfig.event_start_ledger | N/A | u32 | Synced from event contract
EventConfig.event_end_ledger | N/A | u32 | Synced from event contract
EventConfig.withdrawal_delay_ledgers | N/A | u32 | Synced from event contract
EventConfig.admin_delay_extension_ledgers | N/A | u32 | Starts at 0; admin-incremented
EventConfig.cancel_ledger | N/A | u32 | 0 when not cancelled
EventConfig.withdrawable_ratio_bps | N/A | u32 | 0–10 000
EventConfig.organizer_withdrawn | N/A | bool | Guards against double-withdrawal


<p><strong>Edge cases covered:</strong></p>
<ul>
<li>[ ] <code>withdrawal_delay_ledgers = 0</code> (immediate withdrawal)</li>
<li>[ ] <code>cancel_ledger = event_start_ledger</code> (boundary: exactly at start)</li>
<li>[ ] <code>cancel_ledger = event_end_ledger</code> (boundary: exactly at end)</li>
<li>[ ] Organizer attempts withdrawal before cancellation window clears</li>
<li>[ ] Attendee calls <code>claim_refund</code> on a non-cancelled event</li>
</ul>
<p><strong>Test count:</strong> 84 total (new/updated breakdown: not provided)</p>
<hr>
<h2>Acceptance criteria sign-off</h2>
<p><em>(Inferred from the feature — replace with exact AC text from #120)</em></p>
<ul>
<li>[ ] <strong>AC:</strong> Organizer cannot withdraw before <code>event_end_ledger + withdrawal_delay_ledgers</code>
<ul>
<li>Satisfied by: <code>test_withdraw_blocked_before_delay</code> — reads ledger state, asserts error</li>
</ul>
</li>
<li>[ ] <strong>AC:</strong> Admin can extend withdrawal delay after event creation
<ul>
<li>Satisfied by: <code>test_extend_withdrawal_delay_non_admin_rejected</code> + happy-path test</li>
</ul>
</li>
<li>[ ] <strong>AC:</strong> Cancellation before event start results in 0% organizer payout
<ul>
<li>Satisfied by: <code>test_cancel_before_start_ratio_zero</code> — reads <code>withdrawable_ratio_bps</code> from storage</li>
</ul>
</li>
<li>[ ] <strong>AC:</strong> Cancellation mid-event results in proportional organizer payout
<ul>
<li>Satisfied by: <code>test_cancel_mid_event_ratio_proportional</code></li>
</ul>
</li>
<li>[ ] <strong>AC:</strong> Attendees can claim refunds after cancellation
<ul>
<li>Satisfied by: <code>claim_refund</code> happy-path test + double-claim rejection test</li>
</ul>
</li>
</ul>
<hr>
<h2>What this PR deliberately does NOT cover</h2>
<ul>
<li>Per-attendee refund tracking flag — <strong>potential double-claim gap, needs its own issue if not addressed here</strong></li>
<li>On-chain events/emissions for cancellation, withdrawal, and refund state transitions — tracked in &lt;!-- #___ --&gt;</li>
<li>Protocol-enforced minimum <code>withdrawal_delay_ledgers</code> — tracked in &lt;!-- #___ --&gt;</li>
<li>Migration plan for existing <code>Event</code> / <code>EventConfig</code> records — tracked in &lt;!-- #___ --&gt;</li>
<li>Organizer dispute of computed <code>withdrawable_ratio_bps</code> — out of scope</li>
</ul>
<hr>
<h2>Reviewer focus areas</h2>
<ol>
<li><strong><code>claim_refund</code> in <code>payments/src/lib.rs</code></strong> — is there a per-attendee claimed flag? If not, double-claim is possible. This is the highest-risk gap.</li>
<li><strong>BPS arithmetic in <code>cancel_event</code> and <code>withdraw</code></strong> — confirm checked ops are used when multiplying <code>withdrawable_ratio_bps</code> by payment amounts.</li>
<li><strong><code>cancel_ledger</code> sentinel</strong> — verify <code>0</code> cannot be confused with ledger 0 on a real network. Consider <code>Option&lt;u32&gt;</code>.</li>
<li><strong><code>sync_event_config</code> callers</strong> — confirm no external contract calls this with the old signature.</li>
<li><strong><code>validate_revenue_invariant</code> skip condition</strong> — ensure the check <code>is_cancelled</code> is authoritative and cannot be spoofed to skip invariant validation on a live event.</li>
</ol>
<hr>
<h2>Checklist</h2>
<ul>
<li>[ ] My code follows the project's style guidelines</li>
<li>[ ] I have run <code>cargo fmt</code> and <code>cargo clippy</code></li>
<li>[x] I have performed a self-review of my code</li>
<li>[ ] I have commented my code, particularly in hard-to-understand areas</li>
<li>[ ] I have made corresponding changes to the documentation</li>
<li>[x] My changes generate no new warnings</li>
<li>[x] I have added tests that prove my fix is effective or that my feature works</li>
<li>[x] New and existing unit tests pass locally with my changes (<code>cargo test --workspace</code>: 84/84 ✅)</li>
<li>[ ] Any dependent changes have been merged and published</li>
</ul>
<hr>
<h2>Additional Notes</h2>
<p><strong>Key open questions before merge:</strong></p>
<ol>
<li>Is there a per-attendee claimed record in <code>claim_refund</code>? Not visible in the summary — this is a potential drain vector.</li>
<li>Were any <code>Event</code> / <code>EventCancelled</code> / <code>WithdrawalUnlocked</code> emissions added? If not, indexers and the frontend will have no signal for these transitions.</li>
<li>What is the intended behaviour when <code>withdrawal_delay_ledgers = 0</code>? Is that a valid product state or should there be a floor?</li>
</ol></body></html>