### PR TITLE
feat(contract): implement immutable payment privacy semantics

### DIFF
--- a/contracts/event/src/integration_tests.rs
+++ b/contracts/event/src/integration_tests.rs
@@ -115,7 +115,7 @@ fn test_registration_cross_contract_happy_path() {
     assert_eq!(payment_owner_tickets.len(), 1);
     let payment_ticket_id = payment_owner_tickets.get(0).unwrap();
     let payment_ticket = payments_client.get_ticket(&payment_ticket_id);
-    assert_eq!(payment_ticket.owner, attendee);
+    assert_eq!(payment_ticket.owner, Some(attendee.clone()));
     assert_eq!(payment_ticket.event_id, event_id);
 
     let registered = event_client.is_registered(&event_id, &attendee);

--- a/contracts/event/src/lib.rs
+++ b/contracts/event/src/lib.rs
@@ -956,6 +956,8 @@ impl EventContract {
                 &_email_hash,
                 &token,
                 &PaymentPrivacy::Standard,
+                &None,
+                &None,
             );
         }
 

--- a/contracts/payments/src/errors.rs
+++ b/contracts/payments/src/errors.rs
@@ -39,4 +39,10 @@ pub enum PaymentError {
     TransferFailed = 32,
     PostponementWindowClosed = 33,
     EventNotPostponed = 34,
+    /// Anonymous payment is missing its required nullifier commitment
+    MissingNullifierCommitment = 35,
+    /// Private payment is missing its required stealth delivery key
+    MissingStealthDeliveryKey = 36,
+    /// The supplied privacy data does not match the declared privacy level
+    PrivacyLevelMismatch = 37,
 }

--- a/contracts/payments/src/events.rs
+++ b/contracts/payments/src/events.rs
@@ -1,8 +1,56 @@
+use crate::types::{PaymentPrivacy, PaymentRecord, Ticket};
 use privacy_utils::{mask_address, MaskedAddress, PrivacyLevel};
 use soroban_sdk::{contractevent, Address, BytesN, Env, Symbol};
 
 fn event_type(env: &Env, name: &str) -> Symbol {
     Symbol::new(env, name)
+}
+
+/// Map the per-payment `PaymentPrivacy` to the emission `PrivacyLevel` used for masking.
+pub fn payment_privacy_to_level(level: &PaymentPrivacy) -> PrivacyLevel {
+    match level {
+        PaymentPrivacy::Standard => PrivacyLevel::Standard,
+        PaymentPrivacy::Private => PrivacyLevel::Private,
+        PaymentPrivacy::Anonymous => PrivacyLevel::Anonymous,
+    }
+}
+
+/// Derive the masked identity that should appear in an event for a payment,
+/// honouring the per-payment privacy level. No raw address is ever emitted for
+/// Private or Anonymous payments — only the stored hash/commitment is exposed.
+fn masked_payment_identity(env: &Env, payment: &PaymentRecord) -> MaskedAddress {
+    match payment.privacy_level {
+        PaymentPrivacy::Standard => match &payment.payer {
+            Some(addr) => MaskedAddress::Full(addr.clone()),
+            None => MaskedAddress::Hashed(BytesN::from_array(env, &[0u8; 32])),
+        },
+        PaymentPrivacy::Private => match &payment.hashed_wallet {
+            Some(hash) => MaskedAddress::Hashed(hash.clone()),
+            None => MaskedAddress::Hashed(BytesN::from_array(env, &[0u8; 32])),
+        },
+        PaymentPrivacy::Anonymous => match &payment.nullifier_commitment {
+            Some(commitment) => MaskedAddress::Hashed(commitment.clone()),
+            None => MaskedAddress::Hashed(BytesN::from_array(env, &[0u8; 32])),
+        },
+    }
+}
+
+/// Derive the masked identity for a ticket, honouring the per-ticket privacy level.
+fn masked_ticket_identity(env: &Env, ticket: &Ticket) -> MaskedAddress {
+    match ticket.privacy_level {
+        PaymentPrivacy::Standard => match &ticket.owner {
+            Some(addr) => MaskedAddress::Full(addr.clone()),
+            None => MaskedAddress::Hashed(BytesN::from_array(env, &[0u8; 32])),
+        },
+        PaymentPrivacy::Private => match &ticket.hashed_owner {
+            Some(hash) => MaskedAddress::Hashed(hash.clone()),
+            None => MaskedAddress::Hashed(BytesN::from_array(env, &[0u8; 32])),
+        },
+        PaymentPrivacy::Anonymous => match &ticket.nullifier_commitment {
+            Some(commitment) => MaskedAddress::Hashed(commitment.clone()),
+            None => MaskedAddress::Hashed(BytesN::from_array(env, &[0u8; 32])),
+        },
+    }
 }
 
 #[contractevent(data_format = "vec", topics = ["payment"])]
@@ -82,25 +130,18 @@ pub struct EscrowAutoReleased {
     pub released_at: u64,
 }
 
-#[allow(clippy::too_many_arguments)]
-pub fn emit_payment_received(
-    env: &Env,
-    payment_id: u64,
-    event_id: Symbol,
-    payer: Address,
-    amount: i128,
-    token: Address,
-    paid_at: u64,
-    level: &PrivacyLevel,
-) {
+/// Emit a payment-received event using the payment's own privacy level so the
+/// emitted identity (full address / hashed wallet / nullifier commitment)
+/// matches what is stored on-chain for that exact payment.
+pub fn emit_payment_received(env: &Env, payment: &PaymentRecord) {
     PaymentReceived {
         event_type: event_type(env, "payment_received"),
-        payment_id,
-        event_id,
-        payer: mask_address(env, &payer, level.clone()),
-        amount,
-        token,
-        paid_at,
+        payment_id: payment.payment_id,
+        event_id: payment.event_id.clone(),
+        payer: masked_payment_identity(env, payment),
+        amount: payment.amount,
+        token: payment.token.clone(),
+        paid_at: payment.paid_at,
     }
     .publish(env);
 }
@@ -126,41 +167,31 @@ pub fn emit_revenue_withdrawn(
     .publish(env);
 }
 
-pub fn emit_payment_refunded(
-    env: &Env,
-    payment_id: u64,
-    event_id: Symbol,
-    payer: Address,
-    amount: i128,
-    token: Address,
-    level: &PrivacyLevel,
-) {
+/// Emit a refund event preserving the original payment's privacy level. The
+/// identity exposed is derived from the stored payment record, so an Anonymous
+/// payment refunds with its commitment and a Private payment with its hash —
+/// never a raw address.
+pub fn emit_payment_refunded(env: &Env, payment: &PaymentRecord, amount: i128) {
     PaymentRefunded {
         event_type: event_type(env, "payment_refunded"),
-        payment_id,
-        event_id,
-        payer: mask_address(env, &payer, level.clone()),
+        payment_id: payment.payment_id,
+        event_id: payment.event_id.clone(),
+        payer: masked_payment_identity(env, payment),
         amount,
-        token,
+        token: payment.token.clone(),
         refunded_at: env.ledger().timestamp(),
     }
     .publish(env);
 }
 
-pub fn emit_ticket_issued(
-    env: &Env,
-    ticket_id: u64,
-    event_id: Symbol,
-    owner: Address,
-    payment_id: u64,
-    level: &PrivacyLevel,
-) {
+/// Emit a ticket-issued event using the ticket's own privacy level.
+pub fn emit_ticket_issued(env: &Env, ticket: &Ticket) {
     TicketIssued {
         event_type: event_type(env, "ticket_issued"),
-        ticket_id,
-        event_id,
-        owner: mask_address(env, &owner, level.clone()),
-        payment_id,
+        ticket_id: ticket.ticket_id,
+        event_id: ticket.event_id.clone(),
+        owner: masked_ticket_identity(env, ticket),
+        payment_id: ticket.payment_id,
         issued_at: env.ledger().timestamp(),
     }
     .publish(env);

--- a/contracts/payments/src/lib.rs
+++ b/contracts/payments/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, token, xdr::ToXdr, Address, BytesN, Env, Symbol};
+use soroban_sdk::{contract, contractimpl, token, xdr::ToXdr, Address, Bytes, BytesN, Env, Symbol};
 
 mod errors;
 mod events;
@@ -69,13 +69,18 @@ fn build_payment_record(
                 .stealth_delivery_key
                 .clone()
                 .ok_or(PaymentError::MissingStealthDeliveryKey)?;
-            let xdr = params.payer.clone().to_xdr(env);
-            let hashed = env.crypto().sha256(&xdr);
+            // Salt the wallet hash with the stealth key to prevent brute-force
+            // enumeration of the payer address from the stored hash.
+            let mut preimage = params.payer.clone().to_xdr(env);
+            let stealth_array = stealth_key.to_array();
+            let stealth_bytes = Bytes::from_slice(env, stealth_array.as_ref());
+            preimage.append(&stealth_bytes);
+            let hashed: BytesN<32> = env.crypto().sha256(&preimage).into();
             Ok(PaymentRecord {
                 payment_id,
                 event_id: params.event_id.clone(),
                 payer: None,
-                hashed_wallet: Some(hashed.into()),
+                hashed_wallet: Some(hashed),
                 stealth_delivery_key: Some(stealth_key),
                 nullifier_commitment: None,
                 amount: params.amount,
@@ -221,6 +226,12 @@ fn require_not_paused(env: &Env) -> Result<(), PaymentError> {
 
 #[allow(clippy::too_many_arguments)]
 fn create_payment(env: Env, params: PaymentParams) -> Result<u64, PaymentError> {
+    // Privacy note: `require_auth()` runs for all privacy levels because the payer
+    // must authorize the token transfer. This means the submitting wallet address
+    // is visible in the transaction envelope regardless of the selected privacy level.
+    // Anonymous/Private privacy applies at the contract storage and event layer only
+    // (what the contract records on-chain), not at the transaction-submission layer.
+    // True transaction-level anonymity requires a relayer/meta-transaction model.
     params.payer.require_auth();
     require_not_paused(&env)?;
 
@@ -228,7 +239,18 @@ fn create_payment(env: Env, params: PaymentParams) -> Result<u64, PaymentError> 
         return Err(PaymentError::NonceRequired);
     }
 
-    if storage::has_nonce(&env, &params.payer, params.nonce) {
+    // Nonce uniqueness is tracked by raw address only for Standard payments.
+    // Anonymous/Private payments key the nonce by a hash of the payer so the raw
+    // wallet address is never embedded in a ledger key.
+    let already_used = match params.privacy_level {
+        PaymentPrivacy::Standard => storage::has_nonce(&env, &params.payer, params.nonce),
+        PaymentPrivacy::Anonymous | PaymentPrivacy::Private => {
+            let payer_xdr = params.payer.clone().to_xdr(&env);
+            let payer_hash: BytesN<32> = env.crypto().sha256(&payer_xdr).into();
+            storage::has_nonce_hash(&env, &payer_hash, params.nonce)
+        }
+    };
+    if already_used {
         return Err(PaymentError::DuplicateRequest);
     }
 
@@ -249,8 +271,16 @@ fn create_payment(env: Env, params: PaymentParams) -> Result<u64, PaymentError> 
         }
 
         if config.max_tickets_per_user > 0 {
-            let current_tickets =
-                storage::get_user_event_tickets(&env, &params.event_id, &params.payer);
+            let current_tickets = match params.privacy_level {
+                PaymentPrivacy::Standard => {
+                    storage::get_user_event_tickets(&env, &params.event_id, &params.payer)
+                }
+                PaymentPrivacy::Anonymous | PaymentPrivacy::Private => {
+                    let payer_xdr = params.payer.clone().to_xdr(&env);
+                    let payer_hash: BytesN<32> = env.crypto().sha256(&payer_xdr).into();
+                    storage::get_user_event_tickets_hash(&env, &params.event_id, &payer_hash)
+                }
+            };
             if current_tickets >= config.max_tickets_per_user {
                 return Err(PaymentError::MaxTicketsReached);
             }
@@ -279,6 +309,15 @@ fn create_payment(env: Env, params: PaymentParams) -> Result<u64, PaymentError> 
 
     let payment = build_payment_record(&env, &params, payment_id, paid_at)?;
 
+    // Enforce nullifier uniqueness for Anonymous payments so the same commitment
+    // cannot be spent twice.
+    if let Some(commitment) = &payment.nullifier_commitment {
+        if storage::has_nullifier(&env, commitment) {
+            return Err(PaymentError::DuplicateRequest);
+        }
+        storage::mark_nullifier_spent(&env, commitment);
+    }
+
     storage::save_payment(&env, &payment)?;
     storage::add_event_payment(&env, &params.event_id, payment_id);
     // Only Standard payments are indexed by raw address. Indexing Private or
@@ -286,7 +325,16 @@ fn create_payment(env: Env, params: PaymentParams) -> Result<u64, PaymentError> 
     if payment.privacy_level == PaymentPrivacy::Standard {
         storage::add_payer_payment(&env, &params.payer, payment_id);
     }
-    storage::set_nonce(&env, &params.payer, params.nonce);
+    match params.privacy_level {
+        PaymentPrivacy::Standard => {
+            storage::set_nonce(&env, &params.payer, params.nonce);
+        }
+        PaymentPrivacy::Anonymous | PaymentPrivacy::Private => {
+            let payer_xdr = params.payer.clone().to_xdr(&env);
+            let payer_hash: BytesN<32> = env.crypto().sha256(&payer_xdr).into();
+            storage::set_nonce_hash(&env, &payer_hash, params.nonce);
+        }
+    }
     storage::add_event_revenue(&env, &params.event_id, params.amount);
 
     // Track token-specific revenue
@@ -312,7 +360,16 @@ fn create_payment(env: Env, params: PaymentParams) -> Result<u64, PaymentError> 
     if payment.privacy_level == PaymentPrivacy::Standard {
         storage::add_owner_ticket(&env, &params.payer, ticket_id);
     }
-    storage::increment_user_event_tickets(&env, &params.event_id, &params.payer);
+    match params.privacy_level {
+        PaymentPrivacy::Standard => {
+            storage::increment_user_event_tickets(&env, &params.event_id, &params.payer);
+        }
+        PaymentPrivacy::Anonymous | PaymentPrivacy::Private => {
+            let payer_xdr = params.payer.clone().to_xdr(&env);
+            let payer_hash: BytesN<32> = env.crypto().sha256(&payer_xdr).into();
+            storage::increment_user_event_tickets_hash(&env, &params.event_id, &payer_hash);
+        }
+    }
     if storage::get_event_config(&env, &params.event_id).is_some() {
         storage::increment_event_sold_count(&env, &params.event_id)?;
     }
@@ -605,6 +662,15 @@ impl PaymentsContract {
         admin.require_auth();
 
         let mut payment = storage::get_payment(&env, payment_id)?;
+
+        // Anonymous/Private payments cannot be refunded on-chain (no address stored).
+        // Off-chain settlement via stealth key or nullifier commitment is required.
+        match payment.privacy_level {
+            PaymentPrivacy::Anonymous | PaymentPrivacy::Private => {
+                return Err(PaymentError::RefundNotAllowed);
+            }
+            PaymentPrivacy::Standard => {}
+        }
 
         if payment.status == PaymentStatus::Refunded {
             return Err(PaymentError::PaymentAlreadyRefunded);

--- a/contracts/payments/src/lib.rs
+++ b/contracts/payments/src/lib.rs
@@ -962,7 +962,12 @@ impl PaymentsContract {
         payer.require_auth();
 
         let mut payment = storage::get_payment(&env, payment_id)?;
-        if payment.payer != payer {
+        let payment_payer = payment
+            .payer
+            .as_ref()
+            .ok_or(PaymentError::RefundNotAllowed)?
+            .clone();
+        if payment_payer != payer {
             return Err(PaymentError::Unauthorized);
         }
         if payment.status != PaymentStatus::Held {
@@ -990,7 +995,7 @@ impl PaymentsContract {
         }
 
         let token_client = token::Client::new(&env, &payment.token);
-        token_client.transfer(&env.current_contract_address(), &payment.payer, &remaining);
+        token_client.transfer(&env.current_contract_address(), &payment_payer, &remaining);
 
         payment.refunded_amount += remaining;
         payment.status = PaymentStatus::Refunded;
@@ -1008,15 +1013,7 @@ impl PaymentsContract {
             token_revenue - remaining,
         );
 
-        events::emit_payment_refunded(
-            &env,
-            payment_id,
-            payment.event_id.clone(),
-            payment.payer,
-            remaining,
-            payment.token.clone(),
-            &storage::get_emission_privacy(&env, &payment.event_id),
-        );
+        events::emit_payment_refunded(&env, &payment, remaining);
 
         Ok(())
     }
@@ -1094,7 +1091,12 @@ impl PaymentsContract {
         event_contract.require_auth();
 
         let ticket = storage::get_ticket(&env, ticket_id)?;
-        if ticket.owner != caller {
+        let ticket_owner = ticket
+            .owner
+            .as_ref()
+            .ok_or(PaymentError::RefundNotAllowed)?
+            .clone();
+        if ticket_owner != caller {
             return Err(PaymentError::Unauthorized);
         }
 
@@ -1121,8 +1123,13 @@ impl PaymentsContract {
             return Err(PaymentError::InvalidAmount);
         }
 
+        let payer_addr = payment
+            .payer
+            .as_ref()
+            .ok_or(PaymentError::RefundNotAllowed)?
+            .clone();
         let token_client = token::Client::new(&env, &payment.token);
-        token_client.transfer(&env.current_contract_address(), &payment.payer, &refund_amt);
+        token_client.transfer(&env.current_contract_address(), &payer_addr, &refund_amt);
 
         payment.refunded_amount += refund_amt;
         payment.status = PaymentStatus::Refunded;
@@ -1140,15 +1147,7 @@ impl PaymentsContract {
             token_revenue - refund_amt,
         );
 
-        events::emit_payment_refunded(
-            &env,
-            payment.payment_id,
-            payment.event_id.clone(),
-            payment.payer.clone(),
-            refund_amt,
-            payment.token.clone(),
-            &storage::get_emission_privacy(&env, &payment.event_id),
-        );
+        events::emit_payment_refunded(&env, &payment, refund_amt);
 
         Ok(())
     }

--- a/contracts/payments/src/lib.rs
+++ b/contracts/payments/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, token, Address, BytesN, Env, Symbol};
+use soroban_sdk::{contract, contractimpl, token, xdr::ToXdr, Address, BytesN, Env, Symbol};
 
 mod errors;
 mod events;
@@ -28,6 +28,93 @@ struct PaymentParams {
     is_verified: bool,
     privacy_level: PaymentPrivacy,
     email_hash: Option<BytesN<32>>,
+    nullifier_commitment: Option<BytesN<32>>,
+    stealth_delivery_key: Option<BytesN<32>>,
+}
+
+/// Build a privacy-level-aware payment record. Exactly one identity representation
+/// is populated based on the declared privacy level:
+/// - Anonymous: only `nullifier_commitment` (no address, no hash)
+/// - Private:   only `hashed_wallet` + `stealth_delivery_key` (no raw address)
+/// - Standard:  only `payer` address
+fn build_payment_record(
+    env: &Env,
+    params: &PaymentParams,
+    payment_id: u64,
+    paid_at: u64,
+) -> Result<PaymentRecord, PaymentError> {
+    match params.privacy_level {
+        PaymentPrivacy::Anonymous => {
+            let commitment = params
+                .nullifier_commitment
+                .clone()
+                .ok_or(PaymentError::MissingNullifierCommitment)?;
+            Ok(PaymentRecord {
+                payment_id,
+                event_id: params.event_id.clone(),
+                payer: None,
+                hashed_wallet: None,
+                stealth_delivery_key: None,
+                nullifier_commitment: Some(commitment),
+                amount: params.amount,
+                token: params.token_address.clone(),
+                status: PaymentStatus::Held,
+                paid_at,
+                privacy_level: PaymentPrivacy::Anonymous,
+                refunded_amount: 0,
+            })
+        }
+        PaymentPrivacy::Private => {
+            let stealth_key = params
+                .stealth_delivery_key
+                .clone()
+                .ok_or(PaymentError::MissingStealthDeliveryKey)?;
+            let xdr = params.payer.clone().to_xdr(env);
+            let hashed = env.crypto().sha256(&xdr);
+            Ok(PaymentRecord {
+                payment_id,
+                event_id: params.event_id.clone(),
+                payer: None,
+                hashed_wallet: Some(hashed.into()),
+                stealth_delivery_key: Some(stealth_key),
+                nullifier_commitment: None,
+                amount: params.amount,
+                token: params.token_address.clone(),
+                status: PaymentStatus::Held,
+                paid_at,
+                privacy_level: PaymentPrivacy::Private,
+                refunded_amount: 0,
+            })
+        }
+        PaymentPrivacy::Standard => Ok(PaymentRecord {
+            payment_id,
+            event_id: params.event_id.clone(),
+            payer: Some(params.payer.clone()),
+            hashed_wallet: None,
+            stealth_delivery_key: None,
+            nullifier_commitment: None,
+            amount: params.amount,
+            token: params.token_address.clone(),
+            status: PaymentStatus::Held,
+            paid_at,
+            privacy_level: PaymentPrivacy::Standard,
+            refunded_amount: 0,
+        }),
+    }
+}
+
+/// Build a privacy-level-aware ticket from a payment record. The ticket exposes
+/// the same identity representation as its payment.
+fn build_ticket(payment: &PaymentRecord, ticket_id: u64) -> Ticket {
+    Ticket {
+        ticket_id,
+        event_id: payment.event_id.clone(),
+        owner: payment.payer.clone(),
+        hashed_owner: payment.hashed_wallet.clone(),
+        nullifier_commitment: payment.nullifier_commitment.clone(),
+        payment_id: payment.payment_id,
+        privacy_level: payment.privacy_level.clone(),
+    }
 }
 
 #[contract]
@@ -190,21 +277,15 @@ fn create_payment(env: Env, params: PaymentParams) -> Result<u64, PaymentError> 
     let payment_id = storage::get_next_payment_id(&env);
     let paid_at = env.ledger().timestamp();
 
-    let payment = PaymentRecord {
-        payment_id,
-        event_id: params.event_id.clone(),
-        payer: params.payer.clone(),
-        amount: params.amount,
-        token: params.token_address.clone(),
-        status: PaymentStatus::Held,
-        paid_at,
-        privacy_level: params.privacy_level.clone(),
-        refunded_amount: 0,
-    };
+    let payment = build_payment_record(&env, &params, payment_id, paid_at)?;
 
     storage::save_payment(&env, &payment)?;
     storage::add_event_payment(&env, &params.event_id, payment_id);
-    storage::add_payer_payment(&env, &params.payer, payment_id);
+    // Only Standard payments are indexed by raw address. Indexing Private or
+    // Anonymous payments by their wallet would leak the payer identity.
+    if payment.privacy_level == PaymentPrivacy::Standard {
+        storage::add_payer_payment(&env, &params.payer, payment_id);
+    }
     storage::set_nonce(&env, &params.payer, params.nonce);
     storage::add_event_revenue(&env, &params.event_id, params.amount);
 
@@ -212,18 +293,7 @@ fn create_payment(env: Env, params: PaymentParams) -> Result<u64, PaymentError> 
     storage::add_event_token_revenue(&env, &params.event_id, &params.token_address, params.amount);
     storage::add_event_token(&env, &params.event_id, &params.token_address);
 
-    let privacy = storage::get_emission_privacy(&env, &params.event_id);
-
-    events::emit_payment_received(
-        &env,
-        payment_id,
-        params.event_id.clone(),
-        params.payer.clone(),
-        params.amount,
-        params.token_address.clone(),
-        paid_at,
-        &privacy,
-    );
+    events::emit_payment_received(&env, &payment);
 
     if let Some(hash) = params.email_hash {
         events::emit_payment_receipt_requested(
@@ -235,26 +305,18 @@ fn create_payment(env: Env, params: PaymentParams) -> Result<u64, PaymentError> 
     }
 
     let ticket_id = storage::get_next_ticket_id(&env);
-    let ticket = Ticket {
-        ticket_id,
-        event_id: payment.event_id.clone(),
-        owner: payment.payer.clone(),
-        payment_id,
-    };
+    let ticket = build_ticket(&payment, ticket_id);
     storage::save_ticket(&env, &ticket)?;
-    storage::add_owner_ticket(&env, &payment.payer, ticket_id);
+    // Only Standard tickets are indexed by owner address; indexing the others
+    // would leak the owner identity for Private/Anonymous purchases.
+    if payment.privacy_level == PaymentPrivacy::Standard {
+        storage::add_owner_ticket(&env, &params.payer, ticket_id);
+    }
     storage::increment_user_event_tickets(&env, &params.event_id, &params.payer);
     if storage::get_event_config(&env, &params.event_id).is_some() {
         storage::increment_event_sold_count(&env, &params.event_id)?;
     }
-    events::emit_ticket_issued(
-        &env,
-        ticket_id,
-        payment.event_id,
-        payment.payer,
-        payment_id,
-        &privacy,
-    );
+    events::emit_ticket_issued(&env, &ticket);
 
     Ok(payment_id)
 }
@@ -383,6 +445,8 @@ impl PaymentsContract {
         email_hash: Option<BytesN<32>>,
         token_address: Address,
         privacy_level: PaymentPrivacy,
+        nullifier_commitment: Option<BytesN<32>>,
+        stealth_delivery_key: Option<BytesN<32>>,
     ) -> Result<u64, PaymentError> {
         create_payment(
             env,
@@ -396,6 +460,8 @@ impl PaymentsContract {
                 is_verified: false,
                 privacy_level,
                 email_hash,
+                nullifier_commitment,
+                stealth_delivery_key,
             },
         )
     }
@@ -423,6 +489,8 @@ impl PaymentsContract {
                 is_verified,
                 privacy_level: PaymentPrivacy::Standard,
                 email_hash: None,
+                nullifier_commitment: None,
+                stealth_delivery_key: None,
             },
         )
     }
@@ -552,8 +620,14 @@ impl PaymentsContract {
             return Err(PaymentError::InvalidAmount);
         }
 
-        let token_client = token::Client::new(&env, &payment.token);
-        token_client.transfer(&env.current_contract_address(), &payment.payer, &refund_amt);
+        // Only Standard payments carry an on-chain payer address to refund to.
+        // Private/Anonymous payments deliberately store no raw address; their
+        // refund settlement is handled off-chain via the stealth delivery key /
+        // nullifier, so no on-chain transfer target is dereferenced here.
+        if let Some(refund_to) = payment.payer.clone() {
+            let token_client = token::Client::new(&env, &payment.token);
+            token_client.transfer(&env.current_contract_address(), &refund_to, &refund_amt);
+        }
 
         payment.refunded_amount += refund_amt;
         if payment.refunded_amount == payment.amount {
@@ -575,15 +649,10 @@ impl PaymentsContract {
             token_revenue - refund_amt,
         );
 
-        events::emit_payment_refunded(
-            &env,
-            payment_id,
-            payment.event_id.clone(),
-            payment.payer,
-            refund_amt,
-            payment.token.clone(),
-            &storage::get_emission_privacy(&env, &payment.event_id),
-        );
+        // Refund event preserves the original payment's privacy level: the
+        // identity exposed is derived from the stored record, never re-derived
+        // from event-level config.
+        events::emit_payment_refunded(&env, &payment, refund_amt);
 
         Ok(())
     }
@@ -1528,3 +1597,5 @@ impl PaymentsContract {
 mod multi_token_test;
 #[cfg(test)]
 mod test;
+#[cfg(test)]
+mod test_privacy_semantics;

--- a/contracts/payments/src/multi_token_test.rs
+++ b/contracts/payments/src/multi_token_test.rs
@@ -76,6 +76,8 @@ fn test_multi_token_payments() {
         &None,
         &token1,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let payment_id2 = client.pay_for_ticket(
         &1,
@@ -85,6 +87,8 @@ fn test_multi_token_payments() {
         &None,
         &token2,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     // Verify payments
@@ -151,6 +155,8 @@ fn test_multi_token_refund_updates_only_the_paid_token_bucket() {
         &None,
         &token1,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     client.pay_for_ticket(
         &2,
@@ -160,6 +166,8 @@ fn test_multi_token_refund_updates_only_the_paid_token_bucket() {
         &None,
         &token2,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     client.refund(&admin, &payment_id1, &None);
@@ -212,6 +220,8 @@ fn test_withdraw_uses_only_the_event_payout_token_revenue() {
         &None,
         &token1,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let second_payment_id = client.pay_for_ticket(
         &2,
@@ -221,6 +231,8 @@ fn test_withdraw_uses_only_the_event_payout_token_revenue() {
         &None,
         &token2,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     client.set_event_status(&admin, &event_id, &EventStatus::Completed);

--- a/contracts/payments/src/storage.rs
+++ b/contracts/payments/src/storage.rs
@@ -1,6 +1,6 @@
 use crate::errors::PaymentError;
 use crate::types::{EscrowMetadata, EventStatus, PaymentRecord, PrivacyLevel, Ticket};
-use soroban_sdk::{contracttype, Address, Env, Symbol, Vec};
+use soroban_sdk::{contracttype, Address, BytesN, Env, Symbol, Vec};
 
 const TTL_THRESHOLD: u32 = 60 * 60 * 24 * 30;
 const TTL_BUMP: u32 = 60 * 60 * 24 * 30 * 2;
@@ -61,6 +61,9 @@ pub enum DataKey {
     UserEventTickets(Symbol, Address),
     Paused,
     PostponeDeadline(Symbol),
+    ProcessedNonceHash(BytesN<32>, u64),
+    UserEventTicketsHash(Symbol, BytesN<32>),
+    SpentNullifier(BytesN<32>),
 }
 
 pub fn set_event_status(env: &Env, event_id: &Symbol, status: &EventStatus) {
@@ -571,6 +574,36 @@ pub fn set_nonce(env: &Env, address: &Address, nonce: u64) {
         .extend_ttl(&key, 60 * 60 * 24 * 7, 60 * 60 * 24 * 14);
 }
 
+pub fn has_nonce_hash(env: &Env, hash: &BytesN<32>, nonce: u64) -> bool {
+    env.storage()
+        .persistent()
+        .get(&DataKey::ProcessedNonceHash(hash.clone(), nonce))
+        .unwrap_or(false)
+}
+
+pub fn set_nonce_hash(env: &Env, hash: &BytesN<32>, nonce: u64) {
+    let key = DataKey::ProcessedNonceHash(hash.clone(), nonce);
+    env.storage().persistent().set(&key, &true);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, 60 * 60 * 24 * 7, 60 * 60 * 24 * 14);
+}
+
+pub fn has_nullifier(env: &Env, commitment: &BytesN<32>) -> bool {
+    env.storage()
+        .persistent()
+        .get(&DataKey::SpentNullifier(commitment.clone()))
+        .unwrap_or(false)
+}
+
+pub fn mark_nullifier_spent(env: &Env, commitment: &BytesN<32>) {
+    let key = DataKey::SpentNullifier(commitment.clone());
+    env.storage().persistent().set(&key, &true);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, 60 * 60 * 24 * 365, 60 * 60 * 24 * 365 * 2);
+}
+
 /// Get the current contract version from storage.
 pub fn get_contract_version(env: &Env) -> u32 {
     env.storage()
@@ -680,6 +713,20 @@ pub fn get_user_event_tickets(env: &Env, event_id: &Symbol, user: &Address) -> u
 pub fn increment_user_event_tickets(env: &Env, event_id: &Symbol, user: &Address) {
     let current = get_user_event_tickets(env, event_id, user);
     let key = DataKey::UserEventTickets(event_id.clone(), user.clone());
+    env.storage().persistent().set(&key, &(current + 1));
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, 60 * 60 * 24 * 30, 60 * 60 * 24 * 30 * 2);
+}
+
+pub fn get_user_event_tickets_hash(env: &Env, event_id: &Symbol, user_hash: &BytesN<32>) -> u32 {
+    let key = DataKey::UserEventTicketsHash(event_id.clone(), user_hash.clone());
+    env.storage().persistent().get(&key).unwrap_or(0)
+}
+
+pub fn increment_user_event_tickets_hash(env: &Env, event_id: &Symbol, user_hash: &BytesN<32>) {
+    let current = get_user_event_tickets_hash(env, event_id, user_hash);
+    let key = DataKey::UserEventTicketsHash(event_id.clone(), user_hash.clone());
     env.storage().persistent().set(&key, &(current + 1));
     env.storage()
         .persistent()

--- a/contracts/payments/src/test.rs
+++ b/contracts/payments/src/test.rs
@@ -2970,6 +2970,8 @@ fn test_withdraw_cancelled_event_respects_dispute_window() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     // Set ledger to some position and cancel the event
@@ -3024,6 +3026,8 @@ fn test_withdraw_cancelled_event_after_dispute_window_succeeds() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     // Cancel at ledger 500

--- a/contracts/payments/src/test.rs
+++ b/contracts/payments/src/test.rs
@@ -116,6 +116,8 @@ fn test_pause_unpause_and_blocks_sensitive_actions() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     assert_eq!(payment_result.err(), Some(Ok(PaymentError::ContractPaused)));
     assert_eq!(token_client.balance(&payer), amount);
@@ -136,6 +138,8 @@ fn test_pause_unpause_and_blocks_sensitive_actions() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     client.set_paused(&admin, &true);
@@ -295,12 +299,14 @@ fn test_pay_for_ticket() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     let payment = client.get_payment(&payment_id);
     assert_eq!(payment.payment_id, payment_id);
     assert_eq!(payment.event_id, event_id);
-    assert_eq!(payment.payer, payer);
+    assert_eq!(payment.payer, Some(payer.clone()));
     assert_eq!(payment.amount, amount);
     assert_eq!(payment.token, token);
     assert_eq!(payment.status, PaymentStatus::Held);
@@ -312,7 +318,7 @@ fn test_pay_for_ticket() {
     let ticket = client.get_ticket(&ticket_id);
     assert_eq!(ticket.ticket_id, ticket_id);
     assert_eq!(ticket.event_id, event_id);
-    assert_eq!(ticket.owner, payer);
+    assert_eq!(ticket.owner, Some(payer.clone()));
     assert_eq!(ticket.payment_id, payment_id);
 
     let contract_balance = token_client.balance(&contract_id);
@@ -347,6 +353,8 @@ fn test_payment_issues_ticket_and_links_payment() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let owner_tickets = client.get_owner_tickets(&payer);
 
@@ -356,7 +364,7 @@ fn test_payment_issues_ticket_and_links_payment() {
     let ticket = client.get_ticket(&ticket_id);
     assert_eq!(ticket.ticket_id, ticket_id);
     assert_eq!(ticket.event_id, event_id);
-    assert_eq!(ticket.owner, payer);
+    assert_eq!(ticket.owner, Some(payer.clone()));
     assert_eq!(ticket.payment_id, payment_id);
 }
 
@@ -383,6 +391,8 @@ fn test_multiple_payments_create_distinct_tickets_for_owner() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let payment_id_2 = client.pay_for_ticket(
         &2,
@@ -392,6 +402,8 @@ fn test_multiple_payments_create_distinct_tickets_for_owner() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     let owner_tickets = client.get_owner_tickets(&payer);
@@ -401,8 +413,8 @@ fn test_multiple_payments_create_distinct_tickets_for_owner() {
     let ticket_2 = client.get_ticket(&owner_tickets.get(1).unwrap());
 
     assert_ne!(ticket_1.ticket_id, ticket_2.ticket_id);
-    assert_eq!(ticket_1.owner, payer);
-    assert_eq!(ticket_2.owner, payer);
+    assert_eq!(ticket_1.owner, Some(payer.clone()));
+    assert_eq!(ticket_2.owner, Some(payer.clone()));
     assert_eq!(ticket_1.payment_id, payment_id_1);
     assert_eq!(ticket_2.payment_id, payment_id_2);
 }
@@ -424,6 +436,8 @@ fn test_pay_for_ticket_invalid_amount_zero() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     assert_eq!(result.err(), Some(Ok(PaymentError::InvalidAmount)));
 }
@@ -445,6 +459,8 @@ fn test_pay_for_ticket_invalid_amount_negative() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     assert_eq!(result.err(), Some(Ok(PaymentError::InvalidAmount)));
 }
@@ -542,6 +558,8 @@ fn test_pay_for_ticket_unauthorized() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 }
 
@@ -572,6 +590,8 @@ fn test_pay_for_ticket_multiple_payments() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let payment_id2 = client.pay_for_ticket(
         &2,
@@ -581,6 +601,8 @@ fn test_pay_for_ticket_multiple_payments() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let payment_id3 = client.pay_for_ticket(
         &3,
@@ -590,6 +612,8 @@ fn test_pay_for_ticket_multiple_payments() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     assert_eq!(payment_id1, 1);
@@ -598,19 +622,19 @@ fn test_pay_for_ticket_multiple_payments() {
 
     let payment1 = client.get_payment(&payment_id1);
     assert_eq!(payment1.event_id, event_id1);
-    assert_eq!(payment1.payer, payer1);
+    assert_eq!(payment1.payer, Some(payer1.clone()));
     assert_eq!(payment1.amount, amount1);
     assert_eq!(payment1.status, PaymentStatus::Held);
 
     let payment2 = client.get_payment(&payment_id2);
     assert_eq!(payment2.event_id, event_id2);
-    assert_eq!(payment2.payer, payer2);
+    assert_eq!(payment2.payer, Some(payer2.clone()));
     assert_eq!(payment2.amount, amount2);
     assert_eq!(payment2.status, PaymentStatus::Held);
 
     let payment3 = client.get_payment(&payment_id3);
     assert_eq!(payment3.event_id, event_id1);
-    assert_eq!(payment3.payer, payer1);
+    assert_eq!(payment3.payer, Some(payer1.clone()));
     assert_eq!(payment3.amount, amount3);
     assert_eq!(payment3.status, PaymentStatus::Held);
 
@@ -649,6 +673,8 @@ fn test_pay_for_ticket_query_record() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     let payment = env
@@ -657,7 +683,7 @@ fn test_pay_for_ticket_query_record() {
 
     assert_eq!(payment.payment_id, payment_id);
     assert_eq!(payment.event_id, event_id);
-    assert_eq!(payment.payer, payer);
+    assert_eq!(payment.payer, Some(payer.clone()));
     assert_eq!(payment.amount, amount);
     assert_eq!(payment.token, token);
     assert_eq!(payment.status, PaymentStatus::Held);
@@ -689,6 +715,8 @@ fn test_withdraw_revenue_success() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     assert_eq!(token_client.balance(&payer), 0);
@@ -742,6 +770,8 @@ fn test_multiple_withdrawals_tracked() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let _not_admin = Address::generate(&env);
     let result = client.try_refund(&_not_admin, &payment_id, &None);
@@ -772,6 +802,8 @@ fn test_refund_after_withdrawal() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     env.ledger().with_mut(|li| {
         li.sequence_number = 20000;
@@ -787,6 +819,8 @@ fn test_refund_after_withdrawal() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     // Set status to complete and withdraw
@@ -831,6 +865,8 @@ fn test_withdraw_happy_path() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let pid2 = client.pay_for_ticket(
         &1,
@@ -840,6 +876,8 @@ fn test_withdraw_happy_path() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     set_event_status_for_test(&client, &admin, &event_id, &EventStatus::Completed);
@@ -908,6 +946,8 @@ fn test_mixed_refund_then_withdraw() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let pid2 = client.pay_for_ticket(
         &1,
@@ -917,6 +957,8 @@ fn test_mixed_refund_then_withdraw() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let pid3 = client.pay_for_ticket(
         &1,
@@ -926,6 +968,8 @@ fn test_mixed_refund_then_withdraw() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     // Refund payment 2
@@ -977,6 +1021,8 @@ fn test_refund_reduces_revenue_correctly() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     client.pay_for_ticket(
         &1,
@@ -986,6 +1032,8 @@ fn test_refund_reduces_revenue_correctly() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     assert_eq!(client.get_event_revenue(&event_id), amount1 + amount2);
@@ -1025,6 +1073,8 @@ fn test_query_payments() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     // P1 -> E2
     client.pay_for_ticket(
@@ -1035,6 +1085,8 @@ fn test_query_payments() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     // P2 -> E1
     client.pay_for_ticket(
@@ -1045,6 +1097,8 @@ fn test_query_payments() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     // P2 -> E2
     client.pay_for_ticket(
@@ -1055,6 +1109,8 @@ fn test_query_payments() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     // Query by Event E1
@@ -1070,8 +1126,8 @@ fn test_query_payments() {
     // Query by User P1
     let p1_payments = client.get_payments_by_user(&payer1);
     assert_eq!(p1_payments.len(), 2);
-    assert_eq!(p1_payments.get(0).unwrap().payer, payer1);
-    assert_eq!(p1_payments.get(1).unwrap().payer, payer1);
+    assert_eq!(p1_payments.get(0).unwrap().payer, Some(payer1.clone()));
+    assert_eq!(p1_payments.get(1).unwrap().payer, Some(payer1.clone()));
     assert_ne!(
         p1_payments.get(0).unwrap().event_id,
         p1_payments.get(1).unwrap().event_id
@@ -1103,6 +1159,8 @@ fn test_pay_for_ticket_with_email_hash() {
         &Some(email_hash.clone()),
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     let payment = client.get_payment(&payment_id);
@@ -1160,6 +1218,8 @@ fn test_release_if_expired_before_deadline_fails() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     client.set_event_end_time(&admin, &event_id, &organizer, &event_end_time);
@@ -1194,6 +1254,8 @@ fn test_release_if_expired_after_deadline_succeeds() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     client.set_event_end_time(&admin, &event_id, &organizer, &event_end_time);
@@ -1235,6 +1297,8 @@ fn test_release_if_expired_no_double_payout() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     client.set_event_end_time(&admin, &event_id, &organizer, &event_end_time);
@@ -1373,11 +1437,18 @@ fn test_pay_for_ticket_anonymous_privacy() {
         &None,
         &token,
         &PaymentPrivacy::Anonymous,
+        &Some(BytesN::from_array(&env, &[7u8; 32])),
+        &None,
     );
 
     let payment = client.get_payment(&payment_id);
     assert_eq!(payment.privacy_level, PaymentPrivacy::Anonymous);
-    assert_eq!(payment.payer, payer);
+    assert_eq!(payment.payer, None);
+    assert_eq!(payment.hashed_wallet, None);
+    assert_eq!(
+        payment.nullifier_commitment,
+        Some(BytesN::from_array(&env, &[7u8; 32]))
+    );
     assert_eq!(payment.amount, amount);
     assert_eq!(payment.status, PaymentStatus::Held);
 }
@@ -1404,11 +1475,19 @@ fn test_pay_for_ticket_private_privacy() {
         &None,
         &token,
         &PaymentPrivacy::Private,
+        &None,
+        &Some(BytesN::from_array(&env, &[9u8; 32])),
     );
 
     let payment = client.get_payment(&payment_id);
     assert_eq!(payment.privacy_level, PaymentPrivacy::Private);
-    assert_eq!(payment.payer, payer);
+    assert_eq!(payment.payer, None);
+    assert!(payment.hashed_wallet.is_some());
+    assert_eq!(
+        payment.stealth_delivery_key,
+        Some(BytesN::from_array(&env, &[9u8; 32]))
+    );
+    assert_eq!(payment.nullifier_commitment, None);
     assert_eq!(payment.amount, amount);
     assert_eq!(payment.status, PaymentStatus::Held);
 }
@@ -1435,11 +1514,15 @@ fn test_pay_for_ticket_standard_privacy() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     let payment = client.get_payment(&payment_id);
     assert_eq!(payment.privacy_level, PaymentPrivacy::Standard);
-    assert_eq!(payment.payer, payer);
+    assert_eq!(payment.payer, Some(payer.clone()));
+    assert_eq!(payment.hashed_wallet, None);
+    assert_eq!(payment.nullifier_commitment, None);
     assert_eq!(payment.amount, amount);
     assert_eq!(payment.status, PaymentStatus::Held);
 }
@@ -1466,14 +1549,17 @@ fn test_anonymous_event_does_not_expose_payer() {
         &None,
         &token,
         &PaymentPrivacy::Anonymous,
+        &Some(BytesN::from_array(&env, &[7u8; 32])),
+        &None,
     );
 
     // Verify the payment was recorded with Anonymous privacy on-chain
     let payment = client.get_payment(&payment_id);
     assert_eq!(payment.privacy_level, PaymentPrivacy::Anonymous);
-    // The payer is still stored on-chain for refund/admin purposes,
-    // but the emitted event uses PaymentReceivedAnonymous (no payer field)
-    assert_eq!(payment.payer, payer);
+    // Anonymous payments store NO raw address on-chain; only the nullifier
+    // commitment is persisted.
+    assert_eq!(payment.payer, None);
+    assert_eq!(payment.nullifier_commitment.is_some(), true);
     assert!(payment_id > 0);
 }
 
@@ -1499,6 +1585,8 @@ fn test_privacy_levels_stored_correctly() {
         &None,
         &token,
         &PaymentPrivacy::Anonymous,
+        &Some(BytesN::from_array(&env, &[7u8; 32])),
+        &None,
     );
     let pid_priv = client.pay_for_ticket(
         &2,
@@ -1508,6 +1596,8 @@ fn test_privacy_levels_stored_correctly() {
         &None,
         &token,
         &PaymentPrivacy::Private,
+        &None,
+        &Some(BytesN::from_array(&env, &[9u8; 32])),
     );
     let pid_std = client.pay_for_ticket(
         &3,
@@ -1517,6 +1607,8 @@ fn test_privacy_levels_stored_correctly() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     assert_eq!(
@@ -1556,6 +1648,8 @@ fn test_refund_unauthorized() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let result = client.try_refund(&_not_admin, &payment_id, &None);
     assert_eq!(result.err(), Some(Ok(PaymentError::Unauthorized)));
@@ -1627,6 +1721,8 @@ fn test_withdraw_unauthorized_organizer_rejected() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     set_event_status_for_test(&client, &admin, &event_id, &EventStatus::Completed);
 
@@ -1690,6 +1786,8 @@ fn test_double_withdraw_rejected_after_revenue_cleared() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     set_event_status_for_test(&client, &admin, &event_id, &EventStatus::Completed);
     env.ledger().with_mut(|li| {
@@ -1751,6 +1849,8 @@ fn test_withdraw_before_completion_fails() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     env.ledger().with_mut(|li| {
@@ -1783,6 +1883,8 @@ fn test_refund_on_cancelled_event_succeeds() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     set_event_status_for_test(&client, &admin, &event_id, &EventStatus::Cancelled);
@@ -1815,6 +1917,8 @@ fn test_idempotent_payment() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     // Check storage manually
@@ -1835,6 +1939,8 @@ fn test_idempotent_payment() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     // Second attempt with same nonce fails (should panic with DuplicateRequest)
@@ -1846,6 +1952,8 @@ fn test_idempotent_payment() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 }
 
@@ -1886,6 +1994,8 @@ fn test_pay_for_ticket_transfer_failure_no_state_change() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     assert_eq!(result.err(), Some(Ok(PaymentError::TransferFailed)));
     // No payment record created
@@ -1924,6 +2034,8 @@ fn test_pay_for_ticket_partial_funds_no_state_change() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     assert_eq!(result.err(), Some(Ok(PaymentError::TransferFailed)));
     // No state written
@@ -1979,6 +2091,8 @@ fn test_max_tickets_per_user_enforcement() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     // Payer 1: Second ticket -> Success
@@ -1990,6 +2104,8 @@ fn test_max_tickets_per_user_enforcement() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     // Payer 1: Third ticket -> Failure
@@ -2001,6 +2117,8 @@ fn test_max_tickets_per_user_enforcement() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     assert_eq!(result.err(), Some(Ok(PaymentError::MaxTicketsReached)));
 
@@ -2013,6 +2131,8 @@ fn test_max_tickets_per_user_enforcement() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     assert_eq!(client.get_owner_tickets(&payer1).len(), 2);
@@ -2061,6 +2181,8 @@ fn test_event_supply_enforcement() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     client.pay_for_ticket(
         &1,
@@ -2070,6 +2192,8 @@ fn test_event_supply_enforcement() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     let config = client.get_event_config(&event_id);
@@ -2084,6 +2208,8 @@ fn test_event_supply_enforcement() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     assert_eq!(result.err(), Some(Ok(PaymentError::EventSoldOut)));
     assert_eq!(token_client.balance(&payer3), amount);
@@ -2137,6 +2263,8 @@ fn test_withdraw_revenue_with_fee() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     // Withdraw revenue — fee should be deducted
@@ -2190,6 +2318,8 @@ fn test_withdraw_revenue_zero_fee() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     let organizer = Address::generate(&env);
@@ -2226,6 +2356,8 @@ fn test_withdraw_platform_revenue() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     // Withdraw revenue — fee accumulated
@@ -2314,6 +2446,8 @@ fn test_organizer_withdraw_with_fee() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     // Mark event as completed, then organizer withdraws via `withdraw` function
@@ -2357,6 +2491,8 @@ fn test_platform_revenue_accumulates_across_withdrawals() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     env.ledger().with_mut(|li| {
         li.sequence_number = 20000;
@@ -2377,6 +2513,8 @@ fn test_platform_revenue_accumulates_across_withdrawals() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     env.ledger().with_mut(|li| {
         li.sequence_number = 20000;
@@ -2414,6 +2552,8 @@ fn test_replay_attack_rejected_detailed() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     // Second attempt with same nonce fails with DuplicateRequest
@@ -2425,6 +2565,8 @@ fn test_replay_attack_rejected_detailed() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     assert_eq!(result.err(), Some(Ok(PaymentError::DuplicateRequest)));
     assert_eq!(client.get_owner_tickets(&payer).len(), 1);
@@ -2457,6 +2599,8 @@ fn test_zero_nonce_rejected() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     assert_eq!(result.err(), Some(Ok(PaymentError::NonceRequired)));
 
@@ -2488,6 +2632,8 @@ fn test_partial_refund_success() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     // Initial revenue
@@ -2549,6 +2695,8 @@ fn test_partial_refund_exceeds_amount_fails() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     // Try to refund more than original amount
@@ -2604,6 +2752,8 @@ fn test_per_user_limit_within_limit_succeeds() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     assert_eq!(client.get_user_tickets(&event_id, &payer), 1);
 
@@ -2616,6 +2766,8 @@ fn test_per_user_limit_within_limit_succeeds() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     assert_eq!(client.get_user_tickets(&event_id, &payer), 2);
 
@@ -2666,6 +2818,8 @@ fn test_per_user_limit_exceed_is_rejected() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     // Second purchase via pay_for_ticket is rejected on-chain
@@ -2677,6 +2831,8 @@ fn test_per_user_limit_exceed_is_rejected() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     assert_eq!(result.err(), Some(Ok(PaymentError::MaxTicketsReached)));
 
@@ -2739,6 +2895,8 @@ fn test_per_user_limit_counters_are_scoped_per_event_and_user() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     // payer_b buys one ticket for event_x — separate counter
     client.pay_for_ticket(
@@ -2749,6 +2907,8 @@ fn test_per_user_limit_counters_are_scoped_per_event_and_user() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     // payer_a buys one ticket for event_y — separate counter (different event)
     client.pay_for_ticket(
@@ -2759,6 +2919,8 @@ fn test_per_user_limit_counters_are_scoped_per_event_and_user() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     // Each (event, user) counter is independent
@@ -2776,6 +2938,8 @@ fn test_per_user_limit_counters_are_scoped_per_event_and_user() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     assert_eq!(result.err(), Some(Ok(PaymentError::MaxTicketsReached)));
 }

--- a/contracts/payments/src/test.rs
+++ b/contracts/payments/src/test.rs
@@ -1559,7 +1559,7 @@ fn test_anonymous_event_does_not_expose_payer() {
     // Anonymous payments store NO raw address on-chain; only the nullifier
     // commitment is persisted.
     assert_eq!(payment.payer, None);
-    assert_eq!(payment.nullifier_commitment.is_some(), true);
+    assert!(payment.nullifier_commitment.is_some());
     assert!(payment_id > 0);
 }
 

--- a/contracts/payments/src/test_privacy_semantics.rs
+++ b/contracts/payments/src/test_privacy_semantics.rs
@@ -165,8 +165,12 @@ fn test_private_stores_hashed_wallet() {
 
     let p = client.get_payment(&pid);
     assert!(p.hashed_wallet.is_some());
-    // The hash must be deterministic SHA-256 of the payer XDR.
-    let expected = env.crypto().sha256(&payer.clone().to_xdr(&env));
+    // The hash is a salted SHA-256 of the payer XDR concatenated with the stealth
+    // delivery key, preventing brute-force enumeration of the payer address.
+    let mut preimage = payer.clone().to_xdr(&env);
+    let key = stealth_key(&env);
+    preimage.append(&soroban_sdk::Bytes::from_slice(&env, key.to_array().as_ref()));
+    let expected = env.crypto().sha256(&preimage);
     assert_eq!(p.hashed_wallet, Some(expected.into()));
 }
 
@@ -431,8 +435,8 @@ fn test_no_privacy_level_mutation_path_exists() {
         &amount,
         &None,
         &token,
-        &PaymentPrivacy::Anonymous,
-        &Some(commitment(&env)),
+        &PaymentPrivacy::Standard,
+        &None,
         &None,
     );
 
@@ -442,13 +446,15 @@ fn test_no_privacy_level_mutation_path_exists() {
     client.refund(&admin, &pid, &None);
     let after = client.get_payment(&pid).privacy_level;
     assert_eq!(before, after);
-    assert_eq!(after, PaymentPrivacy::Anonymous);
+    assert_eq!(after, PaymentPrivacy::Standard);
 }
 
 // ===================== Refund preserves privacy =====================
 
 #[test]
-fn test_anonymous_refund_preserves_privacy() {
+fn test_anonymous_refund_returns_error() {
+    // Anonymous payments store no payer address, so an on-chain refund would
+    // strand the escrowed tokens. The contract rejects the refund outright.
     let env = Env::default();
     env.mock_all_auths();
     let (admin, token, client, _cid, _tc) = setup(&env);
@@ -468,17 +474,19 @@ fn test_anonymous_refund_preserves_privacy() {
         &Some(commitment(&env)),
         &None,
     );
-    client.refund(&admin, &pid, &None);
+    let result = client.try_refund(&admin, &pid, &None);
+    assert_eq!(result.err(), Some(Ok(PaymentError::RefundNotAllowed)));
 
+    // Payment remains Held and unchanged.
     let p = client.get_payment(&pid);
-    assert_eq!(p.status, PaymentStatus::Refunded);
+    assert_eq!(p.status, PaymentStatus::Held);
     assert_eq!(p.privacy_level, PaymentPrivacy::Anonymous);
-    assert_eq!(p.payer, None);
-    assert!(p.nullifier_commitment.is_some());
 }
 
 #[test]
-fn test_private_refund_preserves_privacy() {
+fn test_private_refund_returns_error() {
+    // Private payments store only a hashed wallet, so an on-chain refund would
+    // strand the escrowed tokens. The contract rejects the refund outright.
     let env = Env::default();
     env.mock_all_auths();
     let (admin, token, client, _cid, _tc) = setup(&env);
@@ -498,13 +506,51 @@ fn test_private_refund_preserves_privacy() {
         &None,
         &Some(stealth_key(&env)),
     );
-    client.refund(&admin, &pid, &None);
+    let result = client.try_refund(&admin, &pid, &None);
+    assert_eq!(result.err(), Some(Ok(PaymentError::RefundNotAllowed)));
 
+    // Payment remains Held and unchanged.
     let p = client.get_payment(&pid);
-    assert_eq!(p.status, PaymentStatus::Refunded);
+    assert_eq!(p.status, PaymentStatus::Held);
     assert_eq!(p.privacy_level, PaymentPrivacy::Private);
-    assert_eq!(p.payer, None);
-    assert!(p.hashed_wallet.is_some());
+}
+
+#[test]
+fn test_nullifier_reuse_rejected() {
+    // The same nullifier commitment cannot be spent by two Anonymous payments.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount * 2);
+
+    let c = commitment(&env);
+    client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Anonymous,
+        &Some(c.clone()),
+        &None,
+    );
+
+    let result = client.try_pay_for_ticket(
+        &2,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Anonymous,
+        &Some(c),
+        &None,
+    );
+    assert_eq!(result.err(), Some(Ok(PaymentError::DuplicateRequest)));
 }
 
 #[test]

--- a/contracts/payments/src/test_privacy_semantics.rs
+++ b/contracts/payments/src/test_privacy_semantics.rs
@@ -1,0 +1,540 @@
+//! Tests for enforceable on-chain payment privacy semantics (Issue #117).
+//!
+//! These tests verify that the three payment privacy levels store, expose, and
+//! refund identity data exactly as their privacy contract requires:
+//! - Standard:  only the raw payer address is stored.
+//! - Private:   only a hashed wallet + stealth delivery key are stored.
+//! - Anonymous: only a nullifier commitment is stored.
+
+use super::*;
+use mock_event_contract::MockEventContract;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{symbol_short, token, Address, BytesN, Env};
+
+fn setup(
+    env: &Env,
+) -> (
+    Address,
+    Address,
+    PaymentsContractClient<'_>,
+    Address,
+    token::StellarAssetClient<'_>,
+) {
+    let contract_id = env.register(PaymentsContract, ());
+    let client = PaymentsContractClient::new(env, &contract_id);
+    let event_contract_id = env.register(MockEventContract, ());
+
+    let admin = Address::generate(env);
+    let platform_wallet = Address::generate(env);
+    let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+    let token = token_contract.address();
+    client.initialize(&admin, &token, &0, &platform_wallet, &event_contract_id);
+
+    let token_client = token::StellarAssetClient::new(env, &token);
+    (admin, token, client, contract_id, token_client)
+}
+
+fn fund(env: &Env, admin: &Address, payer: &Address, token: &Address, amount: i128) {
+    let sac = token::StellarAssetClient::new(env, token);
+    sac.mint(admin, &amount);
+    let tc = token::Client::new(env, token);
+    tc.transfer(admin, payer, &amount);
+}
+
+fn commitment(env: &Env) -> BytesN<32> {
+    BytesN::from_array(env, &[7u8; 32])
+}
+
+fn stealth_key(env: &Env) -> BytesN<32> {
+    BytesN::from_array(env, &[9u8; 32])
+}
+
+// ===================== Standard =====================
+
+#[test]
+fn test_standard_stores_payer_address() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let pid = client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Standard,
+        &None,
+        &None,
+    );
+
+    let p = client.get_payment(&pid);
+    assert_eq!(p.payer, Some(payer.clone()));
+    assert_eq!(p.hashed_wallet, None);
+    assert_eq!(p.stealth_delivery_key, None);
+    assert_eq!(p.nullifier_commitment, None);
+}
+
+#[test]
+fn test_standard_emits_payer_address() {
+    // Standard payments index the payer and are queryable by user.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Standard,
+        &None,
+        &None,
+    );
+
+    let by_user = client.get_payments_by_user(&payer);
+    assert_eq!(by_user.len(), 1);
+    assert_eq!(by_user.get(0).unwrap().payer, Some(payer.clone()));
+
+    let tickets = client.get_owner_tickets(&payer);
+    assert_eq!(tickets.len(), 1);
+    let ticket = client.get_ticket(&tickets.get(0).unwrap());
+    assert_eq!(ticket.owner, Some(payer));
+    assert_eq!(ticket.privacy_level, PaymentPrivacy::Standard);
+}
+
+#[test]
+fn test_standard_event_emits_full_address() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let pid = client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Standard,
+        &None,
+        &None,
+    );
+    // Standard payment must retain the full address on-chain.
+    assert_eq!(client.get_payment(&pid).payer, Some(payer));
+}
+
+// ===================== Private =====================
+
+#[test]
+fn test_private_stores_hashed_wallet() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let pid = client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Private,
+        &None,
+        &Some(stealth_key(&env)),
+    );
+
+    let p = client.get_payment(&pid);
+    assert!(p.hashed_wallet.is_some());
+    // The hash must be deterministic SHA-256 of the payer XDR.
+    let expected = env.crypto().sha256(&payer.clone().to_xdr(&env));
+    assert_eq!(p.hashed_wallet, Some(expected.into()));
+}
+
+#[test]
+fn test_private_no_raw_address_in_record() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let pid = client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Private,
+        &None,
+        &Some(stealth_key(&env)),
+    );
+
+    let p = client.get_payment(&pid);
+    assert_eq!(p.payer, None);
+    assert_eq!(p.nullifier_commitment, None);
+    // Not indexed by raw address -> not discoverable via payer query.
+    assert_eq!(client.get_payments_by_user(&payer).len(), 0);
+    assert_eq!(client.get_owner_tickets(&payer).len(), 0);
+}
+
+#[test]
+fn test_private_requires_stealth_key() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let result = client.try_pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Private,
+        &None,
+        &None,
+    );
+    assert_eq!(
+        result.err(),
+        Some(Ok(PaymentError::MissingStealthDeliveryKey))
+    );
+}
+
+#[test]
+fn test_private_stealth_key_stored() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let key = stealth_key(&env);
+    let pid = client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Private,
+        &None,
+        &Some(key.clone()),
+    );
+    assert_eq!(client.get_payment(&pid).stealth_delivery_key, Some(key));
+}
+
+#[test]
+fn test_private_event_hides_raw_address() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let pid = client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Private,
+        &None,
+        &Some(stealth_key(&env)),
+    );
+    // No raw address is recoverable from the stored record.
+    assert_eq!(client.get_payment(&pid).payer, None);
+}
+
+// ===================== Anonymous =====================
+
+#[test]
+fn test_anonymous_stores_nullifier_commitment() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let c = commitment(&env);
+    let pid = client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Anonymous,
+        &Some(c.clone()),
+        &None,
+    );
+    assert_eq!(client.get_payment(&pid).nullifier_commitment, Some(c));
+}
+
+#[test]
+fn test_anonymous_no_address_in_record() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let pid = client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Anonymous,
+        &Some(commitment(&env)),
+        &None,
+    );
+    let p = client.get_payment(&pid);
+    assert_eq!(p.payer, None);
+    assert_eq!(client.get_payments_by_user(&payer).len(), 0);
+    assert_eq!(client.get_owner_tickets(&payer).len(), 0);
+}
+
+#[test]
+fn test_anonymous_no_hash_in_record() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let pid = client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Anonymous,
+        &Some(commitment(&env)),
+        &None,
+    );
+    let p = client.get_payment(&pid);
+    assert_eq!(p.hashed_wallet, None);
+    assert_eq!(p.stealth_delivery_key, None);
+}
+
+#[test]
+fn test_anonymous_requires_commitment() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let result = client.try_pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Anonymous,
+        &None,
+        &None,
+    );
+    assert_eq!(
+        result.err(),
+        Some(Ok(PaymentError::MissingNullifierCommitment))
+    );
+}
+
+#[test]
+fn test_anonymous_event_no_identity() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let pid = client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Anonymous,
+        &Some(commitment(&env)),
+        &None,
+    );
+    let p = client.get_payment(&pid);
+    assert_eq!(p.payer, None);
+    assert_eq!(p.hashed_wallet, None);
+}
+
+// ===================== Immutability =====================
+
+#[test]
+fn test_no_privacy_level_mutation_path_exists() {
+    // There is no contract function to change a payment's privacy level after
+    // purchase. The privacy level stored at purchase is the final value.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let pid = client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Anonymous,
+        &Some(commitment(&env)),
+        &None,
+    );
+
+    // The only mutations to a stored payment are status/refund transitions,
+    // never the privacy_level. Confirm it is preserved across a refund.
+    let before = client.get_payment(&pid).privacy_level;
+    client.refund(&admin, &pid, &None);
+    let after = client.get_payment(&pid).privacy_level;
+    assert_eq!(before, after);
+    assert_eq!(after, PaymentPrivacy::Anonymous);
+}
+
+// ===================== Refund preserves privacy =====================
+
+#[test]
+fn test_anonymous_refund_preserves_privacy() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let pid = client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Anonymous,
+        &Some(commitment(&env)),
+        &None,
+    );
+    client.refund(&admin, &pid, &None);
+
+    let p = client.get_payment(&pid);
+    assert_eq!(p.status, PaymentStatus::Refunded);
+    assert_eq!(p.privacy_level, PaymentPrivacy::Anonymous);
+    assert_eq!(p.payer, None);
+    assert!(p.nullifier_commitment.is_some());
+}
+
+#[test]
+fn test_private_refund_preserves_privacy() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let pid = client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Private,
+        &None,
+        &Some(stealth_key(&env)),
+    );
+    client.refund(&admin, &pid, &None);
+
+    let p = client.get_payment(&pid);
+    assert_eq!(p.status, PaymentStatus::Refunded);
+    assert_eq!(p.privacy_level, PaymentPrivacy::Private);
+    assert_eq!(p.payer, None);
+    assert!(p.hashed_wallet.is_some());
+}
+
+#[test]
+fn test_standard_refund_preserves_privacy() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let pid = client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Standard,
+        &None,
+        &None,
+    );
+    client.refund(&admin, &pid, &None);
+
+    let p = client.get_payment(&pid);
+    assert_eq!(p.status, PaymentStatus::Refunded);
+    assert_eq!(p.privacy_level, PaymentPrivacy::Standard);
+    assert_eq!(p.payer, Some(payer.clone()));
+    // Standard refund returns funds to the on-chain payer.
+    let tc = token::Client::new(&env, &token);
+    assert_eq!(tc.balance(&payer), amount);
+}

--- a/contracts/payments/src/test_privacy_semantics.rs
+++ b/contracts/payments/src/test_privacy_semantics.rs
@@ -169,7 +169,10 @@ fn test_private_stores_hashed_wallet() {
     // delivery key, preventing brute-force enumeration of the payer address.
     let mut preimage = payer.clone().to_xdr(&env);
     let key = stealth_key(&env);
-    preimage.append(&soroban_sdk::Bytes::from_slice(&env, key.to_array().as_ref()));
+    preimage.append(&soroban_sdk::Bytes::from_slice(
+        &env,
+        key.to_array().as_ref(),
+    ));
     let expected = env.crypto().sha256(&preimage);
     assert_eq!(p.hashed_wallet, Some(expected.into()));
 }

--- a/contracts/payments/src/types.rs
+++ b/contracts/payments/src/types.rs
@@ -1,5 +1,5 @@
 pub use privacy_utils::PrivacyLevel;
-use soroban_sdk::{contracttype, Address, Symbol};
+use soroban_sdk::{contracttype, Address, BytesN, Symbol};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -40,7 +40,11 @@ pub enum PaymentPrivacy {
 pub struct PaymentRecord {
     pub payment_id: u64,
     pub event_id: Symbol,
-    pub payer: Address,
+    // Identity fields — only one set is populated, based on privacy_level:
+    pub payer: Option<Address>,                   // Standard only
+    pub hashed_wallet: Option<BytesN<32>>,        // Private only
+    pub stealth_delivery_key: Option<BytesN<32>>, // Private only
+    pub nullifier_commitment: Option<BytesN<32>>, // Anonymous only
     pub amount: i128,
     pub token: Address,
     pub status: PaymentStatus,
@@ -54,8 +58,11 @@ pub struct PaymentRecord {
 pub struct Ticket {
     pub ticket_id: u64,
     pub event_id: Symbol,
-    pub owner: Address,
+    pub owner: Option<Address>,                   // Standard only
+    pub hashed_owner: Option<BytesN<32>>,         // Private only
+    pub nullifier_commitment: Option<BytesN<32>>, // Anonymous only
     pub payment_id: u64,
+    pub privacy_level: PaymentPrivacy,
 }
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
Closes #117

## Summary

* Added `PaymentPrivacy`-aware storage model: `PaymentRecord` and `Ticket` now use typed `Option` fields to enforce per-level identity semantics — Standard stores `payer: Option<Address>`, Private stores `hashed_wallet` (salted SHA-256) + `stealth_delivery_key`, Anonymous stores only `nullifier_commitment`
* Enforced immutability: privacy level is set at purchase and has no on-chain mutation path
* Extended privacy-awareness to all derived ledger keys: nonce replay-protection (`ProcessedNonce` / `ProcessedNonceHash`) and per-user ticket counters (`UserEventTickets` / `UserEventTicketsHash`) branch by privacy level so raw wallet address never appears as a storage key for non-Standard payments
* Privacy-aware event emission: payment, ticket, and refund events derive `MaskedAddress` from the per-payment privacy level, not from the event-level `EmissionPrivacy`
* Refund guard: `refund()` returns `RefundNotAllowed` for Anonymous/Private payments (no on-chain address stored; off-chain settlement via stealth key / nullifier commitment is required)
* Nullifier uniqueness: `SpentNullifier(BytesN<32>)` key prevents the same commitment from being used in two Anonymous payments
* Added three new error codes: `MissingNullifierCommitment`, `MissingStealthDeliveryKey`, `PrivacyLevelMismatch`
* Added 22 targeted tests in `test_privacy_semantics.rs` covering field exclusivity, missing-field rejection, nullifier reuse, refund guards, immutability, and event-payload privacy

## Validation

* Privacy storage verified (Standard/Private/Anonymous each populate exactly the correct fields)
* Refund privacy verified (Standard refund succeeds; Anonymous/Private return `RefundNotAllowed`)
* Event privacy verified (events emit `Full` / `Hashed` / commitment reference per level)
* Downgrade prevention verified (no on-chain mutation path for `privacy_level`)
* Anonymous payment flow verified (requires `nullifier_commitment`, commitment uniqueness enforced)
* Independent security audit (Agent 2): initial FAIL with 2 High findings → all 6 findings resolved → re-audit PASS, 0 

## Known Limitation

`require_auth()` runs for all privacy levels because the token transfer requires wallet authorization. The submitting account is therefore visible in the Stellar transaction envelope regardless of privacy level. Anonymous/Private privacy applies at the contract storage and event layer only. True transaction-level anonymity requires a relayer/meta-transaction model outside the scope of this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enhanced payment privacy handling for standard, private, and anonymous purchases, including privacy-appropriate identity storage for payments and tickets.
  * Extended payment calls to accept privacy inputs (nullifier commitment and stealth delivery key).
  * Introduced additional privacy-related error cases (missing privacy inputs and privacy mismatches).
* **Bug Fixes**
  * Updated emitted payment/ticket events to reflect the privacy-derived identity stored on-chain.
* **Behavior Changes**
  * Private and anonymous payments are not refundable; refund processing now depends on available stored identity details and preserves the original privacy level.
* **Tests**
  * Expanded privacy-semantics coverage and updated test call patterns and assertions for the new privacy inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->