### PR TITLE
feat: add postponement flow distinct from cancellation #123

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,18 +81,23 @@ The `event` contract is the most developed and supports:
 - **Get Event / Status** — query event details or status by ID
 - **Update Status** — organizer-controlled transitions: `Upcoming → Active → Completed`
 - **Cancel Event** — organizer can cancel any non-completed event
-- **Postpone Event** — organizer can reschedule an `Active` event instead of cancelling it. Postponement opens a refund-choice window (≥72h) in which holders may opt out for a **full** refund via `request_postponement_refund`; holders who do nothing keep their ticket for the new date. Revenue withdrawal is frozen while `Postponed`. After the window closes, anyone may call `finalize_postponement` to return the event to `Active` on its new schedule. Bounded by `MAX_POSTPONEMENTS` to prevent indefinite postponement.
+- **Postpone Event** — organizer can reschedule an `Active` event instead of cancelling it. Postponement opens a refund-choice window (≥72h) in which holders may opt out for a **full** refund via `request_postponement_refund` (which also revokes their ticket so they can't both refund and attend); holders who do nothing keep their ticket for the new date. Revenue withdrawal is frozen while `Postponed`. After the window closes, the organizer calls `finalize_postponement` to return the event to `Active` on its new schedule. A `Postponed` event can still be cancelled outright (full-refund path). Bounded by `MAX_POSTPONEMENTS` to prevent indefinite postponement.
 
 ### Event Lifecycle
 
 ```
-Upcoming ──→ Active ──────────→ Completed
-    │          │  ▲
-    │          ▼  │ finalize (after choice window)
-    │       Postponed
-    │          │
-    └──────────┴──→ Cancelled
+Upcoming ─────→ Active ───────────────→ Completed
+    │            │   ▲
+    │            │   │ finalize_postponement
+    │            ▼   │ (after choice window)
+    │          Postponed
+    │            │
+    │            │ cancel_event
+    ▼            ▼
+ Cancelled ◀─────┘
 ```
+
+Cancellation is reachable from `Upcoming`, `Active`, **and** `Postponed` (any non-`Completed` state).
 
 ## Ticket Contract — Current Features
 

--- a/README.md
+++ b/README.md
@@ -81,13 +81,17 @@ The `event` contract is the most developed and supports:
 - **Get Event / Status** — query event details or status by ID
 - **Update Status** — organizer-controlled transitions: `Upcoming → Active → Completed`
 - **Cancel Event** — organizer can cancel any non-completed event
+- **Postpone Event** — organizer can reschedule an `Active` event instead of cancelling it. Postponement opens a refund-choice window (≥72h) in which holders may opt out for a **full** refund via `request_postponement_refund`; holders who do nothing keep their ticket for the new date. Revenue withdrawal is frozen while `Postponed`. After the window closes, anyone may call `finalize_postponement` to return the event to `Active` on its new schedule. Bounded by `MAX_POSTPONEMENTS` to prevent indefinite postponement.
 
 ### Event Lifecycle
 
 ```
-Upcoming ──→ Active ──→ Completed
-    │           │
-    └───────────┴──→ Cancelled
+Upcoming ──→ Active ──────────→ Completed
+    │          │  ▲
+    │          ▼  │ finalize (after choice window)
+    │       Postponed
+    │          │
+    └──────────┴──→ Cancelled
 ```
 
 ## Ticket Contract — Current Features

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The `event` contract is the most developed and supports:
 
 ### Event Lifecycle
 
-```
+```text
 Upcoming ─────→ Active ───────────────→ Completed
     │            │   ▲
     │            │   │ finalize_postponement

--- a/contracts/event/src/errors.rs
+++ b/contracts/event/src/errors.rs
@@ -46,4 +46,8 @@ pub enum EventError {
     PostponementWindowOpen = 33,
     /// The operation requires the event to be in the `Postponed` state.
     EventNotPostponed = 34,
+    /// The caller holds no revocable (valid, unused) ticket for the event, so a
+    /// postponement refund cannot be issued (e.g. the ticket was already used or
+    /// transferred away).
+    NoRefundableTicket = 35,
 }

--- a/contracts/event/src/errors.rs
+++ b/contracts/event/src/errors.rs
@@ -30,4 +30,9 @@ pub enum EventError {
     PrivacyViolation = 24,
     ClaimLimitExceeded = 25,
     ClaimCooldownActive = 26,
+    PostponementWindowTooShort = 27,
+    InvalidPostponementDate = 28,
+    MaxPostponementsReached = 29,
+    PostponementWindowOpen = 30,
+    EventNotPostponed = 31,
 }

--- a/contracts/event/src/events.rs
+++ b/contracts/event/src/events.rs
@@ -47,6 +47,23 @@ pub struct _RefundsProcessed {
     pub processed_at: u64,
 }
 
+#[contractevent(data_format = "vec", topics = ["ev_pp"])]
+pub struct EventPostponed {
+    pub event_id: Symbol,
+    pub new_date_ledger: u64,
+    pub choice_deadline_ledger: u64,
+    pub postpone_count: u32,
+    pub postponed_at: u64,
+}
+
+#[contractevent(data_format = "vec", topics = ["ev_rsm"])]
+pub struct EventResumed {
+    pub event_id: Symbol,
+    pub new_start_ledger: u32,
+    pub new_end_ledger: u32,
+    pub resumed_at: u64,
+}
+
 #[contractevent(data_format = "vec", topics = ["register"])]
 pub struct EventRegistration {
     pub event_id: Symbol,
@@ -124,6 +141,43 @@ pub fn emit_event_cancelled(
 //     }
 //     .publish(env);
 // }
+
+/// Publish a Soroban event when an event is postponed (rescheduled).
+///
+/// Carries no address-derivable fields, so it is privacy-safe for all levels.
+pub fn emit_event_postponed(
+    env: &Env,
+    event_id: &Symbol,
+    new_date_ledger: u64,
+    choice_deadline_ledger: u64,
+    postpone_count: u32,
+) {
+    EventPostponed {
+        event_id: event_id.clone(),
+        new_date_ledger,
+        choice_deadline_ledger,
+        postpone_count,
+        postponed_at: env.ledger().timestamp(),
+    }
+    .publish(env);
+}
+
+/// Publish a Soroban event when a postponed event is finalized back to `Active`
+/// on its new schedule.
+pub fn emit_event_resumed(
+    env: &Env,
+    event_id: &Symbol,
+    new_start_ledger: u32,
+    new_end_ledger: u32,
+) {
+    EventResumed {
+        event_id: event_id.clone(),
+        new_start_ledger,
+        new_end_ledger,
+        resumed_at: env.ledger().timestamp(),
+    }
+    .publish(env);
+}
 
 /// Publish a Soroban event when an attendee registers.
 /// The attendee address is masked according to the event's privacy level.

--- a/contracts/event/src/integration_tests.rs
+++ b/contracts/event/src/integration_tests.rs
@@ -442,7 +442,8 @@ fn test_postpone_full_refund_and_resume() {
     let payment1 = payments_client.get_ticket(&t1).payment_id;
 
     // Opt out through the event contract (orchestrates refund + revocation).
-    event_client.request_postponement_refund(&attendee1, &event_id, &t1);
+    // The event is derived from the payment ticket, so no event_id argument.
+    event_client.request_postponement_refund(&attendee1, &t1);
 
     assert_eq!(token_client.balance(&attendee1), PRICE);
     assert_eq!(token_client.balance(&payments_id), PRICE);
@@ -611,6 +612,79 @@ fn test_postponement_refund_rejects_non_owner() {
         res.err(),
         Some(Ok(payments_contract::PaymentError::Unauthorized))
     );
+}
+
+#[test]
+fn test_postponement_refund_is_event_scoped() {
+    // A refund must revoke access only for the event the payment ticket belongs to,
+    // never for a different event the caller also participates in.
+    let env = setup_env();
+    env.ledger().with_mut(|li| li.sequence_number = 100);
+
+    let (
+        event_client,
+        payments_client,
+        ticket_client,
+        _token_client,
+        token_admin_client,
+        token_address,
+        organizer,
+        _payments_id,
+    ) = setup_linked(&env);
+
+    let attendee = Address::generate(&env);
+    fund(&token_admin_client, &attendee, PRICE * 2);
+
+    let event_a = Symbol::new(&env, "evt_a");
+    let event_b = Symbol::new(&env, "evt_b");
+    create_active_event(
+        &env,
+        &event_client,
+        &organizer,
+        &token_address,
+        event_a.clone(),
+    );
+    create_active_event(
+        &env,
+        &event_client,
+        &organizer,
+        &token_address,
+        event_b.clone(),
+    );
+
+    event_client.register_for_event(&1, &attendee, &event_a, &0, &false, &None);
+    event_client.register_for_event(&2, &attendee, &event_b, &0, &false, &None);
+
+    let new_date = 100 + MIN_WINDOW as u64 + 10_000;
+    event_client.postpone_event(&organizer, &event_a, &new_date, &MIN_WINDOW);
+    event_client.postpone_event(&organizer, &event_b, &new_date, &MIN_WINDOW);
+
+    // Locate the payments receipt ticket that belongs to event B.
+    let tickets = payments_client.get_owner_tickets(&attendee);
+    let mut ticket_b = None;
+    for i in 0..tickets.len() {
+        let tid = tickets.get(i).unwrap();
+        if payments_client.get_ticket(&tid).event_id == event_b {
+            ticket_b = Some(tid);
+        }
+    }
+    let ticket_b = ticket_b.unwrap();
+
+    // Refunding event B's ticket revokes participation in B only — A is untouched.
+    event_client.request_postponement_refund(&attendee, &ticket_b);
+
+    assert!(!event_client.is_registered(&event_b, &attendee));
+    assert!(event_client.is_registered(&event_a, &attendee));
+
+    // Event A's minted ticket stays valid; event B's is cancelled.
+    for tid in ticket_client.get_tickets_by_owner(&attendee).iter() {
+        let minted = ticket_client.get_ticket(&tid);
+        if minted.event_id == event_a {
+            assert_eq!(minted.status, ticket_contract::TicketStatus::Valid);
+        } else if minted.event_id == event_b {
+            assert_eq!(minted.status, ticket_contract::TicketStatus::Cancelled);
+        }
+    }
 }
 
 #[test]

--- a/contracts/event/src/integration_tests.rs
+++ b/contracts/event/src/integration_tests.rs
@@ -395,7 +395,7 @@ fn test_postpone_full_refund_and_resume() {
     let (
         event_client,
         payments_client,
-        _ticket_client,
+        ticket_client,
         token_client,
         token_admin_client,
         token_address,
@@ -429,12 +429,20 @@ fn test_postpone_full_refund_and_resume() {
         EventStatus::Postponed
     );
 
+    // The minted (entry) ticket for attendee1 before opting out.
+    let minted1 = ticket_client
+        .get_tickets_by_owner(&attendee1)
+        .get(0)
+        .unwrap();
+
     let t1 = payments_client
         .get_owner_tickets(&attendee1)
         .get(0)
         .unwrap();
     let payment1 = payments_client.get_ticket(&t1).payment_id;
-    payments_client.request_postponement_refund(&attendee1, &t1);
+
+    // Opt out through the event contract (orchestrates refund + revocation).
+    event_client.request_postponement_refund(&attendee1, &event_id, &t1);
 
     assert_eq!(token_client.balance(&attendee1), PRICE);
     assert_eq!(token_client.balance(&payments_id), PRICE);
@@ -444,11 +452,19 @@ fn test_postpone_full_refund_and_resume() {
         payments_contract::PaymentStatus::Refunded
     );
 
+    // Refunded holder loses participation: registration dropped and ticket cancelled.
+    assert!(!event_client.is_registered(&event_id, &attendee1));
+    assert_eq!(
+        ticket_client.get_ticket(&minted1).status,
+        ticket_contract::TicketStatus::Cancelled
+    );
+
+    // Non-acting holder keeps their place.
     assert!(event_client.is_registered(&event_id, &attendee2));
 
     env.ledger()
         .with_mut(|li| li.sequence_number = 100 + MIN_WINDOW + 1);
-    event_client.finalize_postponement(&event_id);
+    event_client.finalize_postponement(&organizer, &event_id);
     assert_eq!(
         event_client.get_event_status(&event_id),
         EventStatus::Active
@@ -496,10 +512,19 @@ fn test_postponed_event_blocks_all_withdrawals() {
     let new_date = 100 + MIN_WINDOW as u64 + 10_000;
     event_client.postpone_event(&organizer, &event_id, &new_date, &MIN_WINDOW);
 
+    // Event-contract withdrawal path (gated on Completed).
     let res = event_client.try_withdraw_revenue(&organizer, &event_id);
     assert!(res.is_err());
 
+    // Every direct payments-contract release path is frozen while Postponed.
     let res = payments_client.try_withdraw(&organizer, &event_id);
+    assert!(res.is_err());
+    let res = payments_client.try_withdraw_revenue(&event_id, &organizer);
+    assert_eq!(
+        res.err(),
+        Some(Ok(payments_contract::PaymentError::EventNotActive))
+    );
+    let res = payments_client.try_withdraw_token(&organizer, &event_id, &token_address);
     assert!(res.is_err());
 }
 

--- a/contracts/event/src/integration_tests.rs
+++ b/contracts/event/src/integration_tests.rs
@@ -326,6 +326,268 @@ fn test_registration_with_email_hook() {
     assert!(registered);
 }
 
+const MIN_WINDOW: u32 = 51_840;
+const PRICE: i128 = 100_000_000;
+
+#[allow(clippy::type_complexity)]
+fn setup_linked(
+    env: &Env,
+) -> (
+    EventContractClient<'_>,
+    payments_contract::PaymentsContractClient<'_>,
+    ticket_contract::TicketContractClient<'_>,
+    token::Client<'_>,
+    token::StellarAssetClient<'_>,
+    Address, // token address
+    Address, // organizer
+    Address, // payments contract id
+) {
+    let organizer = Address::generate(env);
+
+    let event_contract_id = env.register(EventContract, ());
+    let event_client = EventContractClient::new(env, &event_contract_id);
+
+    let ticket_contract_id = env.register(ticket_contract::TicketContract, ());
+    let ticket_client = ticket_contract::TicketContractClient::new(env, &ticket_contract_id);
+
+    let payments_contract_id = env.register(payments_contract::PaymentsContract, ());
+    let payments_client =
+        payments_contract::PaymentsContractClient::new(env, &payments_contract_id);
+
+    let token_admin = Address::generate(env);
+    let token_address = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let token_admin_client = token::StellarAssetClient::new(env, &token_address);
+    let token_client = token::Client::new(env, &token_address);
+
+    let platform_wallet = Address::generate(env);
+    payments_client.initialize(
+        &organizer,
+        &token_address,
+        &0,
+        &platform_wallet,
+        &event_contract_id,
+    );
+    event_client.initialize(&organizer, &ticket_contract_id, &payments_contract_id);
+
+    (
+        event_client,
+        payments_client,
+        ticket_client,
+        token_client,
+        token_admin_client,
+        token_address,
+        organizer,
+        payments_contract_id,
+    )
+}
+
+fn fund(token_admin_client: &token::StellarAssetClient, to: &Address, amount: i128) {
+    token_admin_client.mint(to, &amount);
+}
+
+#[test]
+fn test_postpone_full_refund_and_resume() {
+    let env = setup_env();
+    env.ledger().with_mut(|li| li.sequence_number = 100);
+
+    let (
+        event_client,
+        payments_client,
+        _ticket_client,
+        token_client,
+        token_admin_client,
+        token_address,
+        organizer,
+        payments_id,
+    ) = setup_linked(&env);
+
+    let attendee1 = Address::generate(&env);
+    let attendee2 = Address::generate(&env);
+    fund(&token_admin_client, &attendee1, PRICE);
+    fund(&token_admin_client, &attendee2, PRICE);
+
+    let event_id = Symbol::new(&env, "evt_pp_1");
+    create_active_event(
+        &env,
+        &event_client,
+        &organizer,
+        &token_address,
+        event_id.clone(),
+    );
+
+    event_client.register_for_event(&1, &attendee1, &event_id, &0, &false, &None);
+    event_client.register_for_event(&2, &attendee2, &event_id, &0, &false, &None);
+    assert_eq!(token_client.balance(&payments_id), PRICE * 2);
+    assert_eq!(payments_client.get_event_revenue(&event_id), PRICE * 2);
+
+    let new_date = 100 + MIN_WINDOW as u64 + 10_000;
+    event_client.postpone_event(&organizer, &event_id, &new_date, &MIN_WINDOW);
+    assert_eq!(
+        event_client.get_event_status(&event_id),
+        EventStatus::Postponed
+    );
+
+    let t1 = payments_client
+        .get_owner_tickets(&attendee1)
+        .get(0)
+        .unwrap();
+    let payment1 = payments_client.get_ticket(&t1).payment_id;
+    payments_client.request_postponement_refund(&attendee1, &t1);
+
+    assert_eq!(token_client.balance(&attendee1), PRICE);
+    assert_eq!(token_client.balance(&payments_id), PRICE);
+    assert_eq!(payments_client.get_event_revenue(&event_id), PRICE);
+    assert_eq!(
+        payments_client.get_payment(&payment1).status,
+        payments_contract::PaymentStatus::Refunded
+    );
+
+    assert!(event_client.is_registered(&event_id, &attendee2));
+
+    env.ledger()
+        .with_mut(|li| li.sequence_number = 100 + MIN_WINDOW + 1);
+    event_client.finalize_postponement(&event_id);
+    assert_eq!(
+        event_client.get_event_status(&event_id),
+        EventStatus::Active
+    );
+    let ev = event_client.get_event(&event_id);
+    assert_eq!(ev.event_start_ledger, new_date as u32);
+
+    assert!(event_client.is_registered(&event_id, &attendee2));
+
+    event_client.update_event_status(&organizer, &event_id, &EventStatus::Completed);
+    event_client.withdraw_revenue(&organizer, &event_id);
+    assert_eq!(token_client.balance(&organizer), PRICE);
+    assert_eq!(token_client.balance(&payments_id), 0);
+}
+
+#[test]
+fn test_postponed_event_blocks_all_withdrawals() {
+    let env = setup_env();
+    env.ledger().with_mut(|li| li.sequence_number = 100);
+
+    let (
+        event_client,
+        payments_client,
+        _ticket_client,
+        _token_client,
+        token_admin_client,
+        token_address,
+        organizer,
+        _payments_id,
+    ) = setup_linked(&env);
+
+    let attendee = Address::generate(&env);
+    fund(&token_admin_client, &attendee, PRICE);
+
+    let event_id = Symbol::new(&env, "evt_pp_2");
+    create_active_event(
+        &env,
+        &event_client,
+        &organizer,
+        &token_address,
+        event_id.clone(),
+    );
+    event_client.register_for_event(&1, &attendee, &event_id, &0, &false, &None);
+
+    let new_date = 100 + MIN_WINDOW as u64 + 10_000;
+    event_client.postpone_event(&organizer, &event_id, &new_date, &MIN_WINDOW);
+
+    let res = event_client.try_withdraw_revenue(&organizer, &event_id);
+    assert!(res.is_err());
+
+    let res = payments_client.try_withdraw(&organizer, &event_id);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_postponement_refund_after_window_closed_fails() {
+    let env = setup_env();
+    env.ledger().with_mut(|li| li.sequence_number = 100);
+
+    let (
+        event_client,
+        payments_client,
+        _ticket_client,
+        _token_client,
+        token_admin_client,
+        token_address,
+        organizer,
+        _payments_id,
+    ) = setup_linked(&env);
+
+    let attendee = Address::generate(&env);
+    fund(&token_admin_client, &attendee, PRICE);
+
+    let event_id = Symbol::new(&env, "evt_pp_3");
+    create_active_event(
+        &env,
+        &event_client,
+        &organizer,
+        &token_address,
+        event_id.clone(),
+    );
+    event_client.register_for_event(&1, &attendee, &event_id, &0, &false, &None);
+
+    let new_date = 100 + MIN_WINDOW as u64 + 10_000;
+    event_client.postpone_event(&organizer, &event_id, &new_date, &MIN_WINDOW);
+
+    env.ledger()
+        .with_mut(|li| li.sequence_number = 100 + MIN_WINDOW + 1);
+    let t = payments_client.get_owner_tickets(&attendee).get(0).unwrap();
+    let res = payments_client.try_request_postponement_refund(&attendee, &t);
+    assert_eq!(
+        res.err(),
+        Some(Ok(
+            payments_contract::PaymentError::PostponementWindowClosed
+        ))
+    );
+}
+
+#[test]
+fn test_postponement_refund_rejects_non_owner() {
+    let env = setup_env();
+    env.ledger().with_mut(|li| li.sequence_number = 100);
+
+    let (
+        event_client,
+        payments_client,
+        _ticket_client,
+        _token_client,
+        token_admin_client,
+        token_address,
+        organizer,
+        _payments_id,
+    ) = setup_linked(&env);
+
+    let attendee = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    fund(&token_admin_client, &attendee, PRICE);
+
+    let event_id = Symbol::new(&env, "evt_pp_4");
+    create_active_event(
+        &env,
+        &event_client,
+        &organizer,
+        &token_address,
+        event_id.clone(),
+    );
+    event_client.register_for_event(&1, &attendee, &event_id, &0, &false, &None);
+
+    let new_date = 100 + MIN_WINDOW as u64 + 10_000;
+    event_client.postpone_event(&organizer, &event_id, &new_date, &MIN_WINDOW);
+
+    let t = payments_client.get_owner_tickets(&attendee).get(0).unwrap();
+    let res = payments_client.try_request_postponement_refund(&attacker, &t);
+    assert_eq!(
+        res.err(),
+        Some(Ok(payments_contract::PaymentError::Unauthorized))
+    );
+}
+
 #[test]
 fn test_withdraw_revenue_integration() {
     let env = setup_env();

--- a/contracts/event/src/integration_tests.rs
+++ b/contracts/event/src/integration_tests.rs
@@ -615,6 +615,61 @@ fn test_postponement_refund_rejects_non_owner() {
 }
 
 #[test]
+fn test_postponement_refund_requires_revocable_ticket() {
+    // If the holder has no valid, unused entry ticket to give up (e.g. it was
+    // already cancelled/transferred), the refund must be rejected — and no money
+    // must move.
+    let env = setup_env();
+    env.ledger().with_mut(|li| li.sequence_number = 100);
+
+    let (
+        event_client,
+        payments_client,
+        ticket_client,
+        token_client,
+        token_admin_client,
+        token_address,
+        organizer,
+        payments_id,
+    ) = setup_linked(&env);
+
+    let attendee = Address::generate(&env);
+    fund(&token_admin_client, &attendee, PRICE);
+
+    let event_id = Symbol::new(&env, "evt_pp_5");
+    create_active_event(
+        &env,
+        &event_client,
+        &organizer,
+        &token_address,
+        event_id.clone(),
+    );
+    event_client.register_for_event(&1, &attendee, &event_id, &0, &false, &None);
+
+    let new_date = 100 + MIN_WINDOW as u64 + 10_000;
+    event_client.postpone_event(&organizer, &event_id, &new_date, &MIN_WINDOW);
+
+    // Holder cancels their entry ticket, so nothing is revocable.
+    let minted = ticket_client
+        .get_tickets_by_owner(&attendee)
+        .get(0)
+        .unwrap();
+    ticket_client.cancel_ticket(&minted, &attendee);
+
+    let t = payments_client.get_owner_tickets(&attendee).get(0).unwrap();
+    let res = event_client.try_request_postponement_refund(&attendee, &t);
+    assert_eq!(res.err(), Some(Ok(crate::EventError::NoRefundableTicket)));
+
+    // No refund was issued: escrow and payment status are unchanged.
+    assert_eq!(token_client.balance(&attendee), 0);
+    assert_eq!(token_client.balance(&payments_id), PRICE);
+    assert_eq!(
+        payments_client.get_payment(&t).status,
+        payments_contract::PaymentStatus::Held
+    );
+}
+
+#[test]
 fn test_postponement_refund_is_event_scoped() {
     // A refund must revoke access only for the event the payment ticket belongs to,
     // never for a different event the caller also participates in.

--- a/contracts/event/src/lib.rs
+++ b/contracts/event/src/lib.rs
@@ -700,24 +700,31 @@ impl EventContract {
             return Err(EventError::EventNotPostponed);
         }
 
-        // Full refund (verifies ownership, Held status and open window; reverts otherwise).
-        payments_client.request_postponement_refund(&attendee, &ticket_id);
-
-        // Cancel one of the attendee's valid minted tickets for this event. The
+        // Locate a revocable (valid, unused) minted ticket for this event BEFORE
+        // issuing any refund, so we never refund a holder who has nothing to give up
+        // (e.g. their entry ticket was already used or transferred away). The
         // attendee owns the ticket, so their auth on this call covers the
-        // owner-gated cancellation.
+        // owner-gated cancellation that follows.
         let ticket_contract = get_ticket_contract(&env)?;
         let ticket_client = TicketContractClient::new(&env, &ticket_contract);
+        let mut revocable: Option<u64> = None;
         for tid in ticket_client.get_tickets_by_owner(&attendee).iter() {
             let minted = ticket_client.get_ticket(&tid);
             if minted.event_id == event_id
                 && !minted.is_used
                 && minted.status == ticket_contract::TicketStatus::Valid
             {
-                ticket_client.cancel_ticket(&tid, &attendee);
+                revocable = Some(tid);
                 break;
             }
         }
+        let revocable = revocable.ok_or(EventError::NoRefundableTicket)?;
+
+        // Full refund (verifies ownership, Held status and open window; reverts otherwise).
+        payments_client.request_postponement_refund(&attendee, &ticket_id);
+
+        // Revoke the entry ticket that we proved exists above.
+        ticket_client.cancel_ticket(&revocable, &attendee);
 
         // Drop the registration only when no valid ticket for this event remains.
         if !has_valid_ticket_for_event(&ticket_client, &attendee, &event_id) {

--- a/contracts/event/src/lib.rs
+++ b/contracts/event/src/lib.rs
@@ -670,46 +670,58 @@ impl EventContract {
     /// their participation so they cannot also attend the rescheduled event.
     ///
     /// Orchestrated here rather than directly on the payments contract because only
-    /// the event contract is linked to both payments and ticket contracts. Sequence:
-    /// the payments contract performs the full token refund (verifying ownership,
-    /// `Held` status and that the choice window is still open — reverting the whole
-    /// call otherwise); this then drops the attendee's event registration and
-    /// cancels their minted ticket for the event. `ticket_id` is the payments-side
-    /// receipt ticket id (as returned by `payments::get_owner_tickets`).
+    /// the event contract is linked to both payments and ticket contracts. The
+    /// target event is derived from the payment ticket itself (not a caller-supplied
+    /// argument) so the refund and the access-revocation always concern the same
+    /// event. Sequence: the payments contract performs the full token refund
+    /// (verifying ownership, `Held` status and that the choice window is still open —
+    /// reverting the whole call otherwise); one of the attendee's valid minted
+    /// tickets for the event is cancelled; and the registration is dropped only once
+    /// the attendee has no remaining valid ticket for the event (so a single-ticket
+    /// refund does not strip a holder who still has other valid tickets).
+    /// `ticket_id` is the payments-side receipt ticket id (as returned by
+    /// `payments::get_owner_tickets`).
     pub fn request_postponement_refund(
         env: Env,
         attendee: Address,
-        event_id: Symbol,
         ticket_id: u64,
     ) -> Result<(), EventError> {
         attendee.require_auth();
+
+        let payments_contract = get_payments_contract(&env)?;
+        let payments_client = PaymentsContractClient::new(&env, &payments_contract);
+
+        // Derive the event from the payment ticket so refund and revocation can
+        // never target different events.
+        let event_id = payments_client.get_ticket(&ticket_id).event_id;
 
         let event = storage::get_event(&env, &event_id)?;
         if event.status != EventStatus::Postponed {
             return Err(EventError::EventNotPostponed);
         }
 
-        let payments_contract = get_payments_contract(&env)?;
-        let payments_client = PaymentsContractClient::new(&env, &payments_contract);
+        // Full refund (verifies ownership, Held status and open window; reverts otherwise).
         payments_client.request_postponement_refund(&attendee, &ticket_id);
 
-        // Revoke participation so a refunded holder cannot attend the resumed event.
-        storage::remove_registration(&env, &event_id, &attendee);
-
+        // Cancel one of the attendee's valid minted tickets for this event. The
+        // attendee owns the ticket, so their auth on this call covers the
+        // owner-gated cancellation.
         let ticket_contract = get_ticket_contract(&env)?;
         let ticket_client = TicketContractClient::new(&env, &ticket_contract);
-        let owned = ticket_client.get_tickets_by_owner(&attendee);
-        for tid in owned.iter() {
+        for tid in ticket_client.get_tickets_by_owner(&attendee).iter() {
             let minted = ticket_client.get_ticket(&tid);
             if minted.event_id == event_id
                 && !minted.is_used
                 && minted.status == ticket_contract::TicketStatus::Valid
             {
-                // The attendee owns the ticket, so their auth on this call covers
-                // the owner-gated cancellation. Cancel one ticket per refunded payment.
                 ticket_client.cancel_ticket(&tid, &attendee);
                 break;
             }
+        }
+
+        // Drop the registration only when no valid ticket for this event remains.
+        if !has_valid_ticket_for_event(&ticket_client, &attendee, &event_id) {
+            storage::remove_registration(&env, &event_id, &attendee);
         }
 
         Ok(())
@@ -1266,6 +1278,26 @@ impl EventContract {
 
         Ok(new_version)
     }
+}
+
+/// Whether `attendee` still holds at least one `Valid`, unused minted ticket for
+/// `event_id`. Used to decide if a postponement refund should drop the attendee's
+/// event registration (only once their last valid ticket is gone).
+fn has_valid_ticket_for_event(
+    ticket_client: &TicketContractClient,
+    attendee: &Address,
+    event_id: &Symbol,
+) -> bool {
+    for tid in ticket_client.get_tickets_by_owner(attendee).iter() {
+        let minted = ticket_client.get_ticket(&tid);
+        if minted.event_id == *event_id
+            && !minted.is_used
+            && minted.status == ticket_contract::TicketStatus::Valid
+        {
+            return true;
+        }
+    }
+    false
 }
 
 #[cfg(test)]

--- a/contracts/event/src/lib.rs
+++ b/contracts/event/src/lib.rs
@@ -16,12 +16,18 @@ pub use storage::*;
 pub use types::*;
 
 use events::{
-    emit_event_cancelled, emit_event_created, emit_event_updated, emit_registration,
-    emit_status_changed,
+    emit_event_cancelled, emit_event_created, emit_event_postponed, emit_event_resumed,
+    emit_event_updated, emit_registration, emit_status_changed,
 };
 
 // Minimum withdrawal delay (in ledgers) that must be enforced for events
 const MIN_WITHDRAWAL_DELAY_LEDGERS: u32 = 100;
+
+// Minimum refund-choice window for a postponement, in ledgers. Set to ~72h (51,840 ledgers) to give ample time for all attendees to claim refunds if they choose.
+const MIN_POSTPONEMENT_CHOICE_WINDOW_LEDGERS: u32 = 51_840;
+
+// Maximum number of times a single event may be postponed.
+const MAX_POSTPONEMENTS: u32 = 2;
 
 #[contract]
 pub struct EventContract;
@@ -456,6 +462,166 @@ impl EventContract {
         }
 
         Ok(())
+    }
+
+    /// Postpone (reschedule) an active event to a new date instead of cancelling it.
+    ///
+    /// This is a distinct lifecycle path from cancellation: the event continues to
+    /// exist and tickets stay valid for the new date. Only an `Active` event can be
+    /// postponed (`Completed`/`Cancelled`/`Upcoming` are rejected). Postponing opens
+    /// a refund-choice window of at least `MIN_POSTPONEMENT_CHOICE_WINDOW_LEDGERS`
+    /// (~72h) during which any holder may opt out for a full refund via the payments
+    /// contract's `request_postponement_refund`. While `Postponed`, every revenue
+    /// withdrawal path is blocked (here and in the payments contract).
+    ///
+    /// `new_date_ledger` must fall strictly after the choice window closes, so
+    /// holders always get their full decision window before the rescheduled date.
+    /// An event may be postponed at most `MAX_POSTPONEMENTS` times.
+    pub fn postpone_event(
+        env: Env,
+        organizer: Address,
+        event_id: Symbol,
+        new_date_ledger: u64,
+        choice_window_ledgers: u32,
+    ) -> Result<(), EventError> {
+        organizer.require_auth();
+
+        let mut event = storage::get_event(&env, &event_id)?;
+
+        if event.organizer != organizer {
+            return Err(EventError::Unauthorized);
+        }
+
+        // Only an Active event can be postponed.
+        if event.status != EventStatus::Active {
+            return Err(EventError::InvalidStatusTransition);
+        }
+
+        // Anti-abuse: cap the number of postponements.
+        let count = storage::get_postpone_count(&env, &event_id);
+        if count >= MAX_POSTPONEMENTS {
+            return Err(EventError::MaxPostponementsReached);
+        }
+
+        // Enforce the mandatory minimum refund-choice window.
+        if choice_window_ledgers < MIN_POSTPONEMENT_CHOICE_WINDOW_LEDGERS {
+            return Err(EventError::PostponementWindowTooShort);
+        }
+
+        let current_ledger = env.ledger().sequence();
+        let choice_deadline_ledger = current_ledger
+            .checked_add(choice_window_ledgers)
+            .ok_or(EventError::InvalidPostponementDate)?;
+
+        // The new date must be strictly after the choice window closes.
+        if new_date_ledger <= choice_deadline_ledger as u64 {
+            return Err(EventError::InvalidPostponementDate);
+        }
+
+        let old_status = event.status.clone();
+        event.status = EventStatus::Postponed;
+        update_event(&env, &event_id, &event)?;
+
+        let postpone_count = count + 1;
+        let info = PostponementInfo {
+            new_date_ledger,
+            choice_deadline_ledger: choice_deadline_ledger as u64,
+            postpone_count,
+        };
+        storage::set_postponement(&env, &event_id, &info);
+
+        emit_status_changed(&env, &event_id, &old_status, &EventStatus::Postponed);
+        emit_event_postponed(
+            &env,
+            &event_id,
+            new_date_ledger,
+            choice_deadline_ledger as u64,
+            postpone_count,
+        );
+
+        // Freeze escrow and open the refund window on the payments side.
+        if has_linked_contracts(&env) {
+            let payments_contract = get_payments_contract(&env)?;
+            let payments_client = PaymentsContractClient::new(&env, &payments_contract);
+            payments_client.postpone_event(&event_id, &organizer, &choice_deadline_ledger);
+        }
+
+        Ok(())
+    }
+
+    /// Finalize a postponement once its refund-choice window has closed, returning
+    /// the event to `Active` on its new schedule.
+    ///
+    /// Permissionless (like `release_if_expired`): anyone may trigger it after the
+    /// deadline so the event is not left stuck in `Postponed` if the organizer is
+    /// inactive. The ledger-based schedule (`event_start_ledger` / `event_end_ledger`)
+    /// is shifted to the new date while preserving the original event duration, and
+    /// the new schedule is synced to the payments contract so escrow/withdrawal
+    /// timing is recomputed against the rescheduled event.
+    pub fn finalize_postponement(env: Env, event_id: Symbol) -> Result<(), EventError> {
+        let mut event = storage::get_event(&env, &event_id)?;
+
+        if event.status != EventStatus::Postponed {
+            return Err(EventError::EventNotPostponed);
+        }
+
+        let info =
+            storage::get_postponement(&env, &event_id).ok_or(EventError::EventNotPostponed)?;
+
+        // The choice window must have closed.
+        if (env.ledger().sequence() as u64) <= info.choice_deadline_ledger {
+            return Err(EventError::PostponementWindowOpen);
+        }
+
+        // Shift the ledger schedule to the new date, preserving the original duration.
+        let duration = event
+            .event_end_ledger
+            .saturating_sub(event.event_start_ledger);
+        let new_start_ledger = info.new_date_ledger as u32;
+        let new_end_ledger = new_start_ledger
+            .checked_add(duration)
+            .ok_or(EventError::InvalidPostponementDate)?;
+        event.event_start_ledger = new_start_ledger;
+        event.event_end_ledger = new_end_ledger;
+
+        event.status = EventStatus::Active;
+        update_event(&env, &event_id, &event)?;
+
+        emit_status_changed(
+            &env,
+            &event_id,
+            &EventStatus::Postponed,
+            &EventStatus::Active,
+        );
+        emit_event_resumed(&env, &event_id, new_start_ledger, new_end_ledger);
+
+        if has_linked_contracts(&env) {
+            let payments_contract = get_payments_contract(&env)?;
+            let payments_client = PaymentsContractClient::new(&env, &payments_contract);
+            // Push the new schedule, then resume the event back to Active.
+            payments_client.sync_event_config(
+                &env.current_contract_address(),
+                &event_id,
+                &event.organizer,
+                &event.payout_token,
+                &event.allow_anonymous,
+                &event.requires_verification,
+                &event.max_tickets_per_user,
+                &event.max_supply,
+                &event.event_start_ledger,
+                &event.event_end_ledger,
+                &event.withdrawal_delay_ledgers,
+            );
+            payments_client.resume_event(&event_id, &event.organizer);
+        }
+
+        Ok(())
+    }
+
+    /// Read the postponement record for an event, if it has ever been postponed.
+    pub fn get_postponement(env: Env, event_id: Symbol) -> Result<PostponementInfo, EventError> {
+        storage::get_event(&env, &event_id)?;
+        storage::get_postponement(&env, &event_id).ok_or(EventError::EventNotPostponed)
     }
 
     /// Reserve a ticket for a specific tier. The reservation is valid for 15 minutes.

--- a/contracts/event/src/lib.rs
+++ b/contracts/event/src/lib.rs
@@ -23,11 +23,20 @@ use events::{
 // Minimum withdrawal delay (in ledgers) that must be enforced for events
 const MIN_WITHDRAWAL_DELAY_LEDGERS: u32 = 100;
 
-// Minimum refund-choice window for a postponement, in ledgers. Set to ~72h (51,840 ledgers) to give ample time for all attendees to claim refunds if they choose.
+// Minimum refund-choice window for a postponement, in ledgers. Set to ~72h
+// (51,840 ledgers at ~5s/ledger) so every holder has ample time to opt out.
 const MIN_POSTPONEMENT_CHOICE_WINDOW_LEDGERS: u32 = 51_840;
 
-// Maximum number of times a single event may be postponed.
-const MAX_POSTPONEMENTS: u32 = 2;
+// Maximum refund-choice window, in ledgers (~30 days). Bounds how long escrow can
+// stay frozen and keeps the payments-side deadline within its storage TTL.
+const MAX_POSTPONEMENT_CHOICE_WINDOW_LEDGERS: u32 = 518_400;
+
+// Maximum number of times a single event may be postponed. The issue does not
+// mandate a specific number — it only flags "postpone indefinitely to avoid
+// refunds" as a spec flaw — so this is an anti-abuse bound: once exhausted the
+// organizer must run the event (-> Completed) or cancel it (-> Cancelled, full
+// refund). Each postponement independently opens a fresh refund window.
+const MAX_POSTPONEMENTS: u32 = 3;
 
 #[contract]
 pub struct EventContract;
@@ -503,9 +512,18 @@ impl EventContract {
             return Err(EventError::MaxPostponementsReached);
         }
 
-        // Enforce the mandatory minimum refund-choice window.
+        // Enforce the mandatory minimum (and a sane maximum) refund-choice window.
         if choice_window_ledgers < MIN_POSTPONEMENT_CHOICE_WINDOW_LEDGERS {
             return Err(EventError::PostponementWindowTooShort);
+        }
+        if choice_window_ledgers > MAX_POSTPONEMENT_CHOICE_WINDOW_LEDGERS {
+            return Err(EventError::InvalidPostponementDate);
+        }
+
+        // The new date is a ledger sequence; it must fit u32 since the event
+        // schedule (`event_start_ledger`/`event_end_ledger`) is stored as u32.
+        if new_date_ledger > u32::MAX as u64 {
+            return Err(EventError::InvalidPostponementDate);
         }
 
         let current_ledger = env.ledger().sequence();
@@ -523,12 +541,18 @@ impl EventContract {
         update_event(&env, &event_id, &event)?;
 
         let postpone_count = count + 1;
-        let info = PostponementInfo {
-            new_date_ledger,
-            choice_deadline_ledger: choice_deadline_ledger as u64,
-            postpone_count,
-        };
-        storage::set_postponement(&env, &event_id, &info);
+        // The active window data and the cumulative anti-abuse counter are stored
+        // separately: the window record is cleared on resume, while the counter
+        // persists for the lifetime of the event to enforce `MAX_POSTPONEMENTS`.
+        storage::set_postpone_count(&env, &event_id, postpone_count);
+        storage::set_postponement(
+            &env,
+            &event_id,
+            &PostponementInfo {
+                new_date_ledger,
+                choice_deadline_ledger: choice_deadline_ledger as u64,
+            },
+        );
 
         emit_status_changed(&env, &event_id, &old_status, &EventStatus::Postponed);
         emit_event_postponed(
@@ -552,14 +576,25 @@ impl EventContract {
     /// Finalize a postponement once its refund-choice window has closed, returning
     /// the event to `Active` on its new schedule.
     ///
-    /// Permissionless (like `release_if_expired`): anyone may trigger it after the
-    /// deadline so the event is not left stuck in `Postponed` if the organizer is
-    /// inactive. The ledger-based schedule (`event_start_ledger` / `event_end_ledger`)
-    /// is shifted to the new date while preserving the original event duration, and
-    /// the new schedule is synced to the payments contract so escrow/withdrawal
-    /// timing is recomputed against the rescheduled event.
-    pub fn finalize_postponement(env: Env, event_id: Symbol) -> Result<(), EventError> {
+    /// Restricted to the organizer (matching every other state-changing entrypoint).
+    /// The organizer is economically motivated to call it: revenue stays frozen
+    /// until the event is resumed and subsequently `Completed`. The ledger schedule
+    /// (`event_start_ledger` / `event_end_ledger`) is shifted to the new date while
+    /// preserving the original event duration, and the new schedule is synced to the
+    /// payments contract so escrow/withdrawal timing is recomputed against it. The
+    /// active postponement record is cleared so getters no longer expose stale data.
+    pub fn finalize_postponement(
+        env: Env,
+        organizer: Address,
+        event_id: Symbol,
+    ) -> Result<(), EventError> {
+        organizer.require_auth();
+
         let mut event = storage::get_event(&env, &event_id)?;
+
+        if event.organizer != organizer {
+            return Err(EventError::Unauthorized);
+        }
 
         if event.status != EventStatus::Postponed {
             return Err(EventError::EventNotPostponed);
@@ -574,10 +609,12 @@ impl EventContract {
         }
 
         // Shift the ledger schedule to the new date, preserving the original duration.
+        // `new_date_ledger` was validated to fit u32 at postponement time.
         let duration = event
             .event_end_ledger
             .saturating_sub(event.event_start_ledger);
-        let new_start_ledger = info.new_date_ledger as u32;
+        let new_start_ledger =
+            u32::try_from(info.new_date_ledger).map_err(|_| EventError::InvalidPostponementDate)?;
         let new_end_ledger = new_start_ledger
             .checked_add(duration)
             .ok_or(EventError::InvalidPostponementDate)?;
@@ -586,6 +623,9 @@ impl EventContract {
 
         event.status = EventStatus::Active;
         update_event(&env, &event_id, &event)?;
+
+        // Clear the active window record; the cumulative postpone counter is retained.
+        storage::remove_postponement(&env, &event_id);
 
         emit_status_changed(
             &env,
@@ -618,10 +658,61 @@ impl EventContract {
         Ok(())
     }
 
-    /// Read the postponement record for an event, if it has ever been postponed.
+    /// Read the active postponement record for an event. Only present while the
+    /// event is `Postponed`; returns `EventNotPostponed` once it has been resumed
+    /// or if it was never postponed (so callers never see stale window data).
     pub fn get_postponement(env: Env, event_id: Symbol) -> Result<PostponementInfo, EventError> {
         storage::get_event(&env, &event_id)?;
         storage::get_postponement(&env, &event_id).ok_or(EventError::EventNotPostponed)
+    }
+
+    /// Opt a ticket holder out of a postponed event for a full refund, and revoke
+    /// their participation so they cannot also attend the rescheduled event.
+    ///
+    /// Orchestrated here rather than directly on the payments contract because only
+    /// the event contract is linked to both payments and ticket contracts. Sequence:
+    /// the payments contract performs the full token refund (verifying ownership,
+    /// `Held` status and that the choice window is still open — reverting the whole
+    /// call otherwise); this then drops the attendee's event registration and
+    /// cancels their minted ticket for the event. `ticket_id` is the payments-side
+    /// receipt ticket id (as returned by `payments::get_owner_tickets`).
+    pub fn request_postponement_refund(
+        env: Env,
+        attendee: Address,
+        event_id: Symbol,
+        ticket_id: u64,
+    ) -> Result<(), EventError> {
+        attendee.require_auth();
+
+        let event = storage::get_event(&env, &event_id)?;
+        if event.status != EventStatus::Postponed {
+            return Err(EventError::EventNotPostponed);
+        }
+
+        let payments_contract = get_payments_contract(&env)?;
+        let payments_client = PaymentsContractClient::new(&env, &payments_contract);
+        payments_client.request_postponement_refund(&attendee, &ticket_id);
+
+        // Revoke participation so a refunded holder cannot attend the resumed event.
+        storage::remove_registration(&env, &event_id, &attendee);
+
+        let ticket_contract = get_ticket_contract(&env)?;
+        let ticket_client = TicketContractClient::new(&env, &ticket_contract);
+        let owned = ticket_client.get_tickets_by_owner(&attendee);
+        for tid in owned.iter() {
+            let minted = ticket_client.get_ticket(&tid);
+            if minted.event_id == event_id
+                && !minted.is_used
+                && minted.status == ticket_contract::TicketStatus::Valid
+            {
+                // The attendee owns the ticket, so their auth on this call covers
+                // the owner-gated cancellation. Cancel one ticket per refunded payment.
+                ticket_client.cancel_ticket(&tid, &attendee);
+                break;
+            }
+        }
+
+        Ok(())
     }
 
     /// Reserve a ticket for a specific tier. The reservation is valid for 15 minutes.

--- a/contracts/event/src/storage.rs
+++ b/contracts/event/src/storage.rs
@@ -25,8 +25,12 @@ pub enum DataKey {
     LastFreeClaim(Symbol, Address),
     /// Organizer-configured sybil-protection settings for a specific event.
     EventClaimSettings(Symbol),
-    /// Postponement data (new date, choice deadline, postpone count) for a specific event.
+    /// Active postponement window (new date, choice deadline) for a specific event.
+    /// Present only while the event is `Postponed`.
     Postponement(Symbol),
+    /// Cumulative number of times an event has been postponed (anti-abuse counter).
+    /// Persists across postponements, independent of the active window record.
+    PostponeCount(Symbol),
     /// Marks a commitment as used for the anonymous free-claim path.
     AnonCommitment(Symbol, BytesN<32>),
     /// Rolling window state (index + count) for the anonymous rate limiter.
@@ -229,9 +233,8 @@ pub fn has_reservation(env: &Env, event_id: &Symbol, attendee: &Address) -> bool
 
 // ── Postponement helpers ──────────────────────────────────────────────────────
 
-/// Persist the postponement record for an event. The record is retained after the
-/// event is finalized back to `Active` so that `postpone_count` survives across
-/// successive postponements (enforcing `MAX_POSTPONEMENTS`).
+/// Persist the active postponement window for an event. Cleared on resume via
+/// [`remove_postponement`].
 pub fn set_postponement(env: &Env, event_id: &Symbol, info: &PostponementInfo) {
     let key = DataKey::Postponement(event_id.clone());
     env.storage().persistent().set(&key, info);
@@ -240,18 +243,62 @@ pub fn set_postponement(env: &Env, event_id: &Symbol, info: &PostponementInfo) {
         .extend_ttl(&key, TTL_THRESHOLD, TTL_BUMP);
 }
 
-/// Read the postponement record for an event, or `None` if it has never been postponed.
+/// Read the active postponement window, or `None` if the event is not postponed.
 pub fn get_postponement(env: &Env, event_id: &Symbol) -> Option<PostponementInfo> {
     env.storage()
         .persistent()
         .get(&DataKey::Postponement(event_id.clone()))
 }
 
-/// Number of times an event has been postponed (0 if never).
+/// Remove the active postponement window when an event resumes to `Active`.
+pub fn remove_postponement(env: &Env, event_id: &Symbol) {
+    env.storage()
+        .persistent()
+        .remove(&DataKey::Postponement(event_id.clone()));
+}
+
+/// Cumulative number of times an event has been postponed (0 if never).
 pub fn get_postpone_count(env: &Env, event_id: &Symbol) -> u32 {
-    get_postponement(env, event_id)
-        .map(|info| info.postpone_count)
-        .unwrap_or(0)
+    env.storage()
+        .persistent()
+        .get(&DataKey::PostponeCount(event_id.clone()))
+        .unwrap_or(0u32)
+}
+
+/// Persist the cumulative postponement counter. Survives across postponements and
+/// across the active-window record being cleared on resume.
+pub fn set_postpone_count(env: &Env, event_id: &Symbol, count: u32) {
+    let key = DataKey::PostponeCount(event_id.clone());
+    env.storage().persistent().set(&key, &count);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, TTL_THRESHOLD, TTL_BUMP);
+}
+
+/// Remove an attendee's registration for an event (used when a postponement refund
+/// revokes participation). Clears the registration flag and drops the attendee from
+/// the public attendee list.
+pub fn remove_registration(env: &Env, event_id: &Symbol, attendee: &Address) {
+    env.storage()
+        .persistent()
+        .remove(&DataKey::Registration(event_id.clone(), attendee.clone()));
+
+    let attendees_key = DataKey::EventAttendees(event_id.clone());
+    let attendees: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&attendees_key)
+        .unwrap_or(Vec::new(env));
+    let mut remaining = Vec::new(env);
+    for a in attendees.iter() {
+        if a != *attendee {
+            remaining.push_back(a);
+        }
+    }
+    env.storage().persistent().set(&attendees_key, &remaining);
+    env.storage()
+        .persistent()
+        .extend_ttl(&attendees_key, TTL_THRESHOLD, TTL_BUMP);
 }
 
 // ── Sybil-resistance helpers ──────────────────────────────────────────────────

--- a/contracts/event/src/storage.rs
+++ b/contracts/event/src/storage.rs
@@ -1,5 +1,5 @@
 use crate::errors::EventError;
-use crate::types::{ClaimSettings, Event, PrivacyLevel};
+use crate::types::{ClaimSettings, Event, PostponementInfo, PrivacyLevel};
 use soroban_sdk::{contracttype, Address, Env, Symbol, Vec};
 
 const CURRENT_VERSION: u32 = 1;
@@ -23,6 +23,8 @@ pub enum DataKey {
     LastFreeClaim(Symbol, Address),
     /// Organizer-configured sybil-protection settings for a specific event.
     EventClaimSettings(Symbol),
+    /// Postponement data (new date, choice deadline, postpone count) for a specific event.
+    Postponement(Symbol),
 }
 
 /// Check if an event exists in storage.
@@ -215,6 +217,33 @@ pub fn get_event_privacy(env: &Env, event_id: &Symbol) -> PrivacyLevel {
 pub fn has_reservation(env: &Env, event_id: &Symbol, attendee: &Address) -> bool {
     let key = DataKey::Reservation(event_id.clone(), attendee.clone());
     env.storage().persistent().has(&key)
+}
+
+// ── Postponement helpers ──────────────────────────────────────────────────────
+
+/// Persist the postponement record for an event. The record is retained after the
+/// event is finalized back to `Active` so that `postpone_count` survives across
+/// successive postponements (enforcing `MAX_POSTPONEMENTS`).
+pub fn set_postponement(env: &Env, event_id: &Symbol, info: &PostponementInfo) {
+    let key = DataKey::Postponement(event_id.clone());
+    env.storage().persistent().set(&key, info);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, TTL_THRESHOLD, TTL_BUMP);
+}
+
+/// Read the postponement record for an event, or `None` if it has never been postponed.
+pub fn get_postponement(env: &Env, event_id: &Symbol) -> Option<PostponementInfo> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Postponement(event_id.clone()))
+}
+
+/// Number of times an event has been postponed (0 if never).
+pub fn get_postpone_count(env: &Env, event_id: &Symbol) -> u32 {
+    get_postponement(env, event_id)
+        .map(|info| info.postpone_count)
+        .unwrap_or(0)
 }
 
 // ── Sybil-resistance helpers ──────────────────────────────────────────────────

--- a/contracts/event/src/test.rs
+++ b/contracts/event/src/test.rs
@@ -1253,3 +1253,221 @@ fn test_create_event_minimum_withdrawal_delay_enforced() {
     let result = client.try_create_event(&params_200);
     assert!(result.is_ok());
 }
+
+// Minimum choice window in ledgers (~72h at 5s/ledger), mirrors the contract constant.
+const MIN_WINDOW: u32 = 51_840;
+
+/// Create an event and move it to `Active`, returning its id.
+fn setup_active_event(env: &Env, client: &EventContractClient, organizer: &Address) -> Symbol {
+    let event_id = setup_event(env, client, organizer);
+    client.update_event_status(organizer, &event_id, &EventStatus::Active);
+    event_id
+}
+
+fn at_sequence(env: &Env, sequence: u32) {
+    env.ledger().with_mut(|li| li.sequence_number = sequence);
+}
+
+#[test]
+fn test_postpone_active_event_opens_window() {
+    let env = setup_env();
+    at_sequence(&env, 100);
+    let contract_id = env.register(EventContract, ());
+    let client = EventContractClient::new(&env, &contract_id);
+    let organizer = Address::generate(&env);
+    let event_id = setup_active_event(&env, &client, &organizer);
+
+    client.postpone_event(&organizer, &event_id, &60_000, &MIN_WINDOW);
+
+    assert_eq!(client.get_event_status(&event_id), EventStatus::Postponed);
+    let info = client.get_postponement(&event_id);
+    assert_eq!(info.new_date_ledger, 60_000);
+    // deadline = current ledger (100) + window
+    assert_eq!(info.choice_deadline_ledger, 100 + MIN_WINDOW as u64);
+    assert_eq!(info.postpone_count, 1);
+}
+
+#[test]
+fn test_postpone_rejects_non_active_states() {
+    let env = setup_env();
+    at_sequence(&env, 100);
+    let contract_id = env.register(EventContract, ());
+    let client = EventContractClient::new(&env, &contract_id);
+    let organizer = Address::generate(&env);
+
+    // Upcoming -> Postponed rejected
+    let event_id = setup_event(&env, &client, &organizer);
+    let res = client.try_postpone_event(&organizer, &event_id, &60_000, &MIN_WINDOW);
+    assert_eq!(res.err(), Some(Ok(EventError::InvalidStatusTransition)));
+
+    // Completed -> Postponed rejected
+    client.update_event_status(&organizer, &event_id, &EventStatus::Active);
+    client.update_event_status(&organizer, &event_id, &EventStatus::Completed);
+    let res = client.try_postpone_event(&organizer, &event_id, &60_000, &MIN_WINDOW);
+    assert_eq!(res.err(), Some(Ok(EventError::InvalidStatusTransition)));
+}
+
+#[test]
+fn test_postpone_rejects_cancelled() {
+    let env = setup_env();
+    at_sequence(&env, 100);
+    let contract_id = env.register(EventContract, ());
+    let client = EventContractClient::new(&env, &contract_id);
+    let organizer = Address::generate(&env);
+    let event_id = setup_active_event(&env, &client, &organizer);
+
+    client.cancel_event(&organizer, &event_id);
+    let res = client.try_postpone_event(&organizer, &event_id, &60_000, &MIN_WINDOW);
+    assert_eq!(res.err(), Some(Ok(EventError::InvalidStatusTransition)));
+}
+
+#[test]
+fn test_postpone_rejects_short_window() {
+    let env = setup_env();
+    at_sequence(&env, 100);
+    let contract_id = env.register(EventContract, ());
+    let client = EventContractClient::new(&env, &contract_id);
+    let organizer = Address::generate(&env);
+    let event_id = setup_active_event(&env, &client, &organizer);
+
+    let res = client.try_postpone_event(&organizer, &event_id, &60_000, &(MIN_WINDOW - 1));
+    assert_eq!(res.err(), Some(Ok(EventError::PostponementWindowTooShort)));
+}
+
+#[test]
+fn test_postpone_rejects_new_date_inside_window() {
+    let env = setup_env();
+    at_sequence(&env, 100);
+    let contract_id = env.register(EventContract, ());
+    let client = EventContractClient::new(&env, &contract_id);
+    let organizer = Address::generate(&env);
+    let event_id = setup_active_event(&env, &client, &organizer);
+
+    // deadline = 100 + MIN_WINDOW; a new date equal to the deadline is rejected.
+    let deadline = 100 + MIN_WINDOW as u64;
+    let res = client.try_postpone_event(&organizer, &event_id, &deadline, &MIN_WINDOW);
+    assert_eq!(res.err(), Some(Ok(EventError::InvalidPostponementDate)));
+}
+
+#[test]
+fn test_postpone_requires_organizer() {
+    let env = setup_env();
+    at_sequence(&env, 100);
+    let contract_id = env.register(EventContract, ());
+    let client = EventContractClient::new(&env, &contract_id);
+    let organizer = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let event_id = setup_active_event(&env, &client, &organizer);
+
+    let res = client.try_postpone_event(&attacker, &event_id, &60_000, &MIN_WINDOW);
+    assert_eq!(res.err(), Some(Ok(EventError::Unauthorized)));
+}
+
+#[test]
+fn test_finalize_before_window_closes_fails() {
+    let env = setup_env();
+    at_sequence(&env, 100);
+    let contract_id = env.register(EventContract, ());
+    let client = EventContractClient::new(&env, &contract_id);
+    let organizer = Address::generate(&env);
+    let event_id = setup_active_event(&env, &client, &organizer);
+
+    client.postpone_event(&organizer, &event_id, &60_000, &MIN_WINDOW);
+    // Still inside the window.
+    let res = client.try_finalize_postponement(&event_id);
+    assert_eq!(res.err(), Some(Ok(EventError::PostponementWindowOpen)));
+}
+
+#[test]
+fn test_finalize_requires_postponed_state() {
+    let env = setup_env();
+    at_sequence(&env, 100);
+    let contract_id = env.register(EventContract, ());
+    let client = EventContractClient::new(&env, &contract_id);
+    let organizer = Address::generate(&env);
+    let event_id = setup_active_event(&env, &client, &organizer);
+
+    let res = client.try_finalize_postponement(&event_id);
+    assert_eq!(res.err(), Some(Ok(EventError::EventNotPostponed)));
+}
+
+#[test]
+fn test_finalize_resumes_active_and_shifts_schedule() {
+    let env = setup_env();
+    at_sequence(&env, 100);
+    let contract_id = env.register(EventContract, ());
+    let client = EventContractClient::new(&env, &contract_id);
+    let organizer = Address::generate(&env);
+    let event_id = setup_active_event(&env, &client, &organizer);
+
+    // Original schedule: start 0, end 1000 (duration 1000) from setup_event.
+    let before = client.get_event(&event_id);
+    let duration = before.event_end_ledger - before.event_start_ledger;
+
+    client.postpone_event(&organizer, &event_id, &60_000, &MIN_WINDOW);
+    at_sequence(&env, 100 + MIN_WINDOW + 1);
+    client.finalize_postponement(&event_id);
+
+    assert_eq!(client.get_event_status(&event_id), EventStatus::Active);
+    let after = client.get_event(&event_id);
+    assert_eq!(after.event_start_ledger, 60_000);
+    assert_eq!(after.event_end_ledger, 60_000 + duration);
+}
+
+#[test]
+fn test_postpone_count_capped() {
+    let env = setup_env();
+    at_sequence(&env, 10);
+    let contract_id = env.register(EventContract, ());
+    let client = EventContractClient::new(&env, &contract_id);
+    let organizer = Address::generate(&env);
+    let event_id = setup_active_event(&env, &client, &organizer);
+
+    // First postponement + finalize.
+    client.postpone_event(&organizer, &event_id, &60_000, &MIN_WINDOW);
+    at_sequence(&env, 10 + MIN_WINDOW + 1);
+    client.finalize_postponement(&event_id);
+
+    // Second postponement + finalize.
+    let seq2 = 10 + MIN_WINDOW + 1;
+    let new_date2 = (seq2 + MIN_WINDOW) as u64 + 10_000;
+    client.postpone_event(&organizer, &event_id, &new_date2, &MIN_WINDOW);
+    at_sequence(&env, seq2 + MIN_WINDOW + 1);
+    client.finalize_postponement(&event_id);
+
+    // Third postponement exceeds MAX_POSTPONEMENTS (2).
+    let seq3 = seq2 + MIN_WINDOW + 1;
+    let new_date3 = (seq3 + MIN_WINDOW) as u64 + 10_000;
+    let res = client.try_postpone_event(&organizer, &event_id, &new_date3, &MIN_WINDOW);
+    assert_eq!(res.err(), Some(Ok(EventError::MaxPostponementsReached)));
+}
+
+#[test]
+fn test_cancel_allowed_from_postponed() {
+    // The organizer can always escape a postponement by cancelling outright,
+    // which routes through the full-refund cancellation path.
+    let env = setup_env();
+    at_sequence(&env, 100);
+    let contract_id = env.register(EventContract, ());
+    let client = EventContractClient::new(&env, &contract_id);
+    let organizer = Address::generate(&env);
+    let event_id = setup_active_event(&env, &client, &organizer);
+
+    client.postpone_event(&organizer, &event_id, &60_000, &MIN_WINDOW);
+    client.cancel_event(&organizer, &event_id);
+    assert_eq!(client.get_event_status(&event_id), EventStatus::Cancelled);
+}
+
+#[test]
+fn test_withdraw_revenue_blocked_while_postponed() {
+    let env = setup_env();
+    at_sequence(&env, 100);
+    let contract_id = env.register(EventContract, ());
+    let client = EventContractClient::new(&env, &contract_id);
+    let organizer = Address::generate(&env);
+    let event_id = setup_active_event(&env, &client, &organizer);
+
+    client.postpone_event(&organizer, &event_id, &60_000, &MIN_WINDOW);
+    let res = client.try_withdraw_revenue(&organizer, &event_id);
+    assert_eq!(res.err(), Some(Ok(EventError::InvalidStatusTransition)));
+}

--- a/contracts/event/src/test.rs
+++ b/contracts/event/src/test.rs
@@ -1284,7 +1284,6 @@ fn test_postpone_active_event_opens_window() {
     assert_eq!(info.new_date_ledger, 60_000);
     // deadline = current ledger (100) + window
     assert_eq!(info.choice_deadline_ledger, 100 + MIN_WINDOW as u64);
-    assert_eq!(info.postpone_count, 1);
 }
 
 #[test]
@@ -1374,8 +1373,24 @@ fn test_finalize_before_window_closes_fails() {
 
     client.postpone_event(&organizer, &event_id, &60_000, &MIN_WINDOW);
     // Still inside the window.
-    let res = client.try_finalize_postponement(&event_id);
+    let res = client.try_finalize_postponement(&organizer, &event_id);
     assert_eq!(res.err(), Some(Ok(EventError::PostponementWindowOpen)));
+}
+
+#[test]
+fn test_finalize_requires_organizer() {
+    let env = setup_env();
+    at_sequence(&env, 100);
+    let contract_id = env.register(EventContract, ());
+    let client = EventContractClient::new(&env, &contract_id);
+    let organizer = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let event_id = setup_active_event(&env, &client, &organizer);
+
+    client.postpone_event(&organizer, &event_id, &60_000, &MIN_WINDOW);
+    at_sequence(&env, 100 + MIN_WINDOW + 1);
+    let res = client.try_finalize_postponement(&attacker, &event_id);
+    assert_eq!(res.err(), Some(Ok(EventError::Unauthorized)));
 }
 
 #[test]
@@ -1387,7 +1402,7 @@ fn test_finalize_requires_postponed_state() {
     let organizer = Address::generate(&env);
     let event_id = setup_active_event(&env, &client, &organizer);
 
-    let res = client.try_finalize_postponement(&event_id);
+    let res = client.try_finalize_postponement(&organizer, &event_id);
     assert_eq!(res.err(), Some(Ok(EventError::EventNotPostponed)));
 }
 
@@ -1406,39 +1421,70 @@ fn test_finalize_resumes_active_and_shifts_schedule() {
 
     client.postpone_event(&organizer, &event_id, &60_000, &MIN_WINDOW);
     at_sequence(&env, 100 + MIN_WINDOW + 1);
-    client.finalize_postponement(&event_id);
+    client.finalize_postponement(&organizer, &event_id);
 
     assert_eq!(client.get_event_status(&event_id), EventStatus::Active);
     let after = client.get_event(&event_id);
     assert_eq!(after.event_start_ledger, 60_000);
     assert_eq!(after.event_end_ledger, 60_000 + duration);
+
+    // The active postponement record is cleared on resume — no stale window data.
+    let res = client.try_get_postponement(&event_id);
+    assert_eq!(res.err(), Some(Ok(EventError::EventNotPostponed)));
 }
 
 #[test]
-fn test_postpone_count_capped() {
+fn test_postpone_rejects_out_of_range_new_date() {
     let env = setup_env();
-    at_sequence(&env, 10);
+    at_sequence(&env, 100);
     let contract_id = env.register(EventContract, ());
     let client = EventContractClient::new(&env, &contract_id);
     let organizer = Address::generate(&env);
     let event_id = setup_active_event(&env, &client, &organizer);
 
-    // First postponement + finalize.
-    client.postpone_event(&organizer, &event_id, &60_000, &MIN_WINDOW);
-    at_sequence(&env, 10 + MIN_WINDOW + 1);
-    client.finalize_postponement(&event_id);
+    // new_date_ledger beyond u32::MAX cannot fit the stored u32 schedule.
+    let too_far = u32::MAX as u64 + 1;
+    let res = client.try_postpone_event(&organizer, &event_id, &too_far, &MIN_WINDOW);
+    assert_eq!(res.err(), Some(Ok(EventError::InvalidPostponementDate)));
+}
 
-    // Second postponement + finalize.
-    let seq2 = 10 + MIN_WINDOW + 1;
-    let new_date2 = (seq2 + MIN_WINDOW) as u64 + 10_000;
-    client.postpone_event(&organizer, &event_id, &new_date2, &MIN_WINDOW);
-    at_sequence(&env, seq2 + MIN_WINDOW + 1);
-    client.finalize_postponement(&event_id);
+#[test]
+fn test_postpone_rejects_window_above_max() {
+    let env = setup_env();
+    at_sequence(&env, 100);
+    let contract_id = env.register(EventContract, ());
+    let client = EventContractClient::new(&env, &contract_id);
+    let organizer = Address::generate(&env);
+    let event_id = setup_active_event(&env, &client, &organizer);
 
-    // Third postponement exceeds MAX_POSTPONEMENTS (2).
-    let seq3 = seq2 + MIN_WINDOW + 1;
-    let new_date3 = (seq3 + MIN_WINDOW) as u64 + 10_000;
-    let res = client.try_postpone_event(&organizer, &event_id, &new_date3, &MIN_WINDOW);
+    // ~30-day cap is 518_400 ledgers; one above is rejected.
+    let res = client.try_postpone_event(&organizer, &event_id, &10_000_000, &518_401);
+    assert_eq!(res.err(), Some(Ok(EventError::InvalidPostponementDate)));
+}
+
+#[test]
+fn test_postpone_count_capped() {
+    let env = setup_env();
+    let contract_id = env.register(EventContract, ());
+    let client = EventContractClient::new(&env, &contract_id);
+    let organizer = Address::generate(&env);
+    let event_id = setup_active_event(&env, &client, &organizer);
+
+    // MAX_POSTPONEMENTS allowed postponements, each followed by a finalize.
+    let mut seq = 10u32;
+    for _ in 0..3 {
+        at_sequence(&env, seq);
+        let new_date = (seq + MIN_WINDOW) as u64 + 10_000;
+        client.postpone_event(&organizer, &event_id, &new_date, &MIN_WINDOW);
+        seq += MIN_WINDOW + 1;
+        at_sequence(&env, seq);
+        client.finalize_postponement(&organizer, &event_id);
+    }
+
+    // The 4th postponement exceeds MAX_POSTPONEMENTS (3).
+    at_sequence(&env, seq);
+    let new_date = (seq + MIN_WINDOW) as u64 + 10_000;
+    let res = client.try_postpone_event(&organizer, &event_id, &new_date, &MIN_WINDOW);
     assert_eq!(res.err(), Some(Ok(EventError::MaxPostponementsReached)));
 }
 

--- a/contracts/event/src/types.rs
+++ b/contracts/event/src/types.rs
@@ -8,6 +8,7 @@ pub enum EventStatus {
     Active = 1,
     Completed = 2,
     Cancelled = 3,
+    Postponed = 4,
 }
 
 #[contracttype]
@@ -92,6 +93,26 @@ pub struct UpdateEventParams {
 pub struct Reservation {
     pub tier_id: u32,
     pub expires_at: u64,
+}
+
+/// Data backing the [`EventStatus::Postponed`] state.
+///
+/// Stored under its own persistent key per event (see `storage::set_postponement`).
+/// `new_date_ledger` and `choice_deadline_ledger` are the two fields named in the
+/// issue's `Postponed { new_date_ledger, choice_deadline_ledger }` specification;
+/// `postpone_count` is an additional anti-abuse counter (see `MAX_POSTPONEMENTS`)
+/// that bounds how many times a single event may be postponed, closing the
+/// "postpone indefinitely to dodge refunds" loophole.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PostponementInfo {
+    /// Ledger sequence at which the rescheduled event is set to start.
+    pub new_date_ledger: u64,
+    /// Ledger sequence after which the refund-choice window closes and the event
+    /// can be finalized back to `Active`.
+    pub choice_deadline_ledger: u64,
+    /// Number of times this event has been postponed, including the current one.
+    pub postpone_count: u32,
 }
 
 /// Per-event configuration controlling free-ticket claim abuse prevention.

--- a/contracts/event/src/types.rs
+++ b/contracts/event/src/types.rs
@@ -95,14 +95,14 @@ pub struct Reservation {
     pub expires_at: u64,
 }
 
-/// Data backing the [`EventStatus::Postponed`] state.
+/// Active window data backing the [`EventStatus::Postponed`] state, matching the
+/// issue's `Postponed { new_date_ledger, choice_deadline_ledger }` specification.
 ///
-/// Stored under its own persistent key per event (see `storage::set_postponement`).
-/// `new_date_ledger` and `choice_deadline_ledger` are the two fields named in the
-/// issue's `Postponed { new_date_ledger, choice_deadline_ledger }` specification;
-/// `postpone_count` is an additional anti-abuse counter (see `MAX_POSTPONEMENTS`)
-/// that bounds how many times a single event may be postponed, closing the
-/// "postpone indefinitely to dodge refunds" loophole.
+/// Stored under its own persistent key per event (see `storage::set_postponement`)
+/// and **removed when the event resumes to `Active`**, so getters never expose
+/// stale window data. The cumulative anti-abuse counter that bounds how many times
+/// an event may be postponed (see `MAX_POSTPONEMENTS`) is tracked separately under
+/// `DataKey::PostponeCount` so it survives across successive postponements.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PostponementInfo {
@@ -111,8 +111,6 @@ pub struct PostponementInfo {
     /// Ledger sequence after which the refund-choice window closes and the event
     /// can be finalized back to `Active`.
     pub choice_deadline_ledger: u64,
-    /// Number of times this event has been postponed, including the current one.
-    pub postpone_count: u32,
 }
 
 /// Per-event configuration controlling free-ticket claim abuse prevention.

--- a/contracts/payments/src/errors.rs
+++ b/contracts/payments/src/errors.rs
@@ -37,4 +37,6 @@ pub enum PaymentError {
     ContractPaused = 31,
     /// Token transfer failed; no state has been modified
     TransferFailed = 32,
+    PostponementWindowClosed = 33,
+    EventNotPostponed = 34,
 }

--- a/contracts/payments/src/lib.rs
+++ b/contracts/payments/src/lib.rs
@@ -943,13 +943,20 @@ impl PaymentsContract {
     }
 
     /// Opt out of a postponed event in exchange for a full refund.
+    ///
+    /// Callable only by the linked event contract, which orchestrates the full
+    /// opt-out (refund here, then registration + ticket revocation on its side) so
+    /// a refunded holder cannot also attend the resumed event. `caller` is the
+    /// ticket owner on whose behalf the event contract is acting; ownership is
+    /// verified here. Refunds 100% of the held amount.
     pub fn request_postponement_refund(
         env: Env,
         caller: Address,
         ticket_id: u64,
     ) -> Result<(), PaymentError> {
         require_not_paused(&env)?;
-        caller.require_auth();
+        let event_contract = storage::get_event_contract(&env)?;
+        event_contract.require_auth();
 
         let ticket = storage::get_ticket(&env, ticket_id)?;
         if ticket.owner != caller {
@@ -1047,6 +1054,11 @@ impl PaymentsContract {
             return Err(PaymentError::EscrowAlreadyReleased);
         }
 
+        // Escrow is frozen while the event is postponed (refund-choice window open).
+        if storage::get_event_status(&env, &event_id) == Some(EventStatus::Postponed) {
+            return Err(PaymentError::EventNotActive);
+        }
+
         if env.ledger().timestamp() < meta.event_end_time {
             return Err(PaymentError::EscrowNotExpired);
         }
@@ -1111,6 +1123,11 @@ impl PaymentsContract {
         require_not_paused(&env)?;
         let admin = storage::get_admin(&env)?;
         admin.require_auth();
+
+        // Escrow is frozen while the event is postponed (refund-choice window open).
+        if storage::get_event_status(&env, &event_id) == Some(EventStatus::Postponed) {
+            return Err(PaymentError::EventNotActive);
+        }
 
         validate_revenue_invariant(&env, &event_id)?;
 

--- a/contracts/payments/src/lib.rs
+++ b/contracts/payments/src/lib.rs
@@ -171,7 +171,10 @@ fn create_payment(env: Env, params: PaymentParams) -> Result<u64, PaymentError> 
     }
 
     if let Some(status) = storage::get_event_status(&env, &params.event_id) {
-        if matches!(status, EventStatus::Completed | EventStatus::Cancelled) {
+        if matches!(
+            status,
+            EventStatus::Completed | EventStatus::Cancelled | EventStatus::Postponed
+        ) {
             return Err(PaymentError::EventNotActive);
         }
     }
@@ -876,6 +879,131 @@ impl PaymentsContract {
             payment.event_id.clone(),
             payment.payer,
             remaining,
+            payment.token.clone(),
+            &storage::get_emission_privacy(&env, &payment.event_id),
+        );
+
+        Ok(())
+    }
+
+    /// Freeze escrow for a postponed event and open the refund-choice window.
+    ///
+    /// Called by the event contract as part of `event::postpone_event`. Sets the
+    /// payments-side status to `Postponed` (which blocks every withdrawal path —
+    /// `withdraw`, `withdraw_token`, `withdraw_all_tokens` all reject any non-
+    /// `Completed`/`Cancelled` status) and records the choice-window deadline used
+    /// by `request_postponement_refund`.
+    pub fn postpone_event(
+        env: Env,
+        event_id: Symbol,
+        organizer: Address,
+        choice_deadline_ledger: u32,
+    ) -> Result<(), PaymentError> {
+        require_not_paused(&env)?;
+        let event_contract = storage::get_event_contract(&env)?;
+        event_contract.require_auth();
+
+        let config =
+            storage::get_event_config(&env, &event_id).ok_or(PaymentError::InvalidOrganizer)?;
+        if config.organizer != organizer {
+            return Err(PaymentError::Unauthorized);
+        }
+
+        storage::set_event_status(&env, &event_id, &EventStatus::Postponed);
+        storage::set_postpone_deadline(&env, &event_id, choice_deadline_ledger);
+        Ok(())
+    }
+
+    /// Resume a postponed event back to `Active` once its choice window has closed.
+    ///
+    /// Called by the event contract as part of `event::finalize_postponement`.
+    /// Clears the choice-window deadline so the refund path is no longer open.
+    pub fn resume_event(
+        env: Env,
+        event_id: Symbol,
+        organizer: Address,
+    ) -> Result<(), PaymentError> {
+        require_not_paused(&env)?;
+        let event_contract = storage::get_event_contract(&env)?;
+        event_contract.require_auth();
+
+        let config =
+            storage::get_event_config(&env, &event_id).ok_or(PaymentError::InvalidOrganizer)?;
+        if config.organizer != organizer {
+            return Err(PaymentError::Unauthorized);
+        }
+
+        if storage::get_event_status(&env, &event_id) != Some(EventStatus::Postponed) {
+            return Err(PaymentError::EventNotPostponed);
+        }
+
+        storage::set_event_status(&env, &event_id, &EventStatus::Active);
+        storage::remove_postpone_deadline(&env, &event_id);
+        Ok(())
+    }
+
+    /// Opt out of a postponed event in exchange for a full refund.
+    pub fn request_postponement_refund(
+        env: Env,
+        caller: Address,
+        ticket_id: u64,
+    ) -> Result<(), PaymentError> {
+        require_not_paused(&env)?;
+        caller.require_auth();
+
+        let ticket = storage::get_ticket(&env, ticket_id)?;
+        if ticket.owner != caller {
+            return Err(PaymentError::Unauthorized);
+        }
+
+        let mut payment = storage::get_payment(&env, ticket.payment_id)?;
+        if payment.status == PaymentStatus::Refunded {
+            return Err(PaymentError::PaymentAlreadyRefunded);
+        }
+        if payment.status != PaymentStatus::Held {
+            return Err(PaymentError::PaymentAlreadyProcessed);
+        }
+
+        if storage::get_event_status(&env, &payment.event_id) != Some(EventStatus::Postponed) {
+            return Err(PaymentError::EventNotPostponed);
+        }
+
+        let deadline = storage::get_postpone_deadline(&env, &payment.event_id)
+            .ok_or(PaymentError::EventNotPostponed)?;
+        if env.ledger().sequence() > deadline {
+            return Err(PaymentError::PostponementWindowClosed);
+        }
+
+        let refund_amt = payment.amount - payment.refunded_amount;
+        if refund_amt <= 0 {
+            return Err(PaymentError::InvalidAmount);
+        }
+
+        let token_client = token::Client::new(&env, &payment.token);
+        token_client.transfer(&env.current_contract_address(), &payment.payer, &refund_amt);
+
+        payment.refunded_amount += refund_amt;
+        payment.status = PaymentStatus::Refunded;
+        storage::update_payment(&env, &payment)?;
+
+        let revenue = storage::get_event_revenue(&env, &payment.event_id);
+        storage::set_event_revenue(&env, &payment.event_id, revenue - refund_amt);
+
+        let token_revenue =
+            storage::get_event_token_revenue(&env, &payment.event_id, &payment.token);
+        storage::set_event_token_revenue(
+            &env,
+            &payment.event_id,
+            &payment.token,
+            token_revenue - refund_amt,
+        );
+
+        events::emit_payment_refunded(
+            &env,
+            payment.payment_id,
+            payment.event_id.clone(),
+            payment.payer.clone(),
+            refund_amt,
             payment.token.clone(),
             &storage::get_emission_privacy(&env, &payment.event_id),
         );

--- a/contracts/payments/src/lib.rs
+++ b/contracts/payments/src/lib.rs
@@ -1063,6 +1063,18 @@ impl PaymentsContract {
             return Err(PaymentError::EscrowNotExpired);
         }
 
+        // When the event has a ledger schedule (set/rescheduled via the event
+        // contract), the timestamp-based escrow metadata is not authoritative on its
+        // own: a postponed-then-resumed event carries a stale `event_end_time`. Also
+        // require the (possibly rescheduled) ledger end to have passed so escrow
+        // cannot auto-release before the rescheduled event actually ends. Events that
+        // only use the legacy timestamp escrow (no config) are unaffected.
+        if let Some(config) = storage::get_event_config(&env, &event_id) {
+            if env.ledger().sequence() < config.event_end_ledger {
+                return Err(PaymentError::EscrowNotExpired);
+            }
+        }
+
         validate_revenue_invariant(&env, &event_id)?;
 
         let tokens = storage::get_event_tokens(&env, &event_id);

--- a/contracts/payments/src/storage.rs
+++ b/contracts/payments/src/storage.rs
@@ -60,6 +60,7 @@ pub enum DataKey {
     ContractVersion,
     UserEventTickets(Symbol, Address),
     Paused,
+    PostponeDeadline(Symbol),
 }
 
 pub fn set_event_status(env: &Env, event_id: &Symbol, status: &EventStatus) {
@@ -74,6 +75,29 @@ pub fn get_event_status(env: &Env, event_id: &Symbol) -> Option<EventStatus> {
     env.storage()
         .persistent()
         .get(&DataKey::EventStatus(event_id.clone()))
+}
+
+/// Store the refund-choice deadline (ledger sequence) for a postponed event.
+pub fn set_postpone_deadline(env: &Env, event_id: &Symbol, deadline_ledger: u32) {
+    let key = DataKey::PostponeDeadline(event_id.clone());
+    env.storage().persistent().set(&key, &deadline_ledger);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, TTL_THRESHOLD, TTL_BUMP);
+}
+
+/// Read the refund-choice deadline (ledger sequence) for a postponed event.
+pub fn get_postpone_deadline(env: &Env, event_id: &Symbol) -> Option<u32> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::PostponeDeadline(event_id.clone()))
+}
+
+/// Clear the refund-choice deadline once a postponed event is resumed.
+pub fn remove_postpone_deadline(env: &Env, event_id: &Symbol) {
+    env.storage()
+        .persistent()
+        .remove(&DataKey::PostponeDeadline(event_id.clone()));
 }
 
 /// Get the admin address from storage.

--- a/contracts/payments/src/storage.rs
+++ b/contracts/payments/src/storage.rs
@@ -78,12 +78,21 @@ pub fn get_event_status(env: &Env, event_id: &Symbol) -> Option<EventStatus> {
 }
 
 /// Store the refund-choice deadline (ledger sequence) for a postponed event.
+///
+/// The TTL is sized dynamically to outlive the configured refund window: a long
+/// window must not let the deadline entry expire before the window closes, which
+/// would make `get_postpone_deadline` return `None` and break refunds while the
+/// event is still postponed. We extend to cover (deadline - now) plus the standard
+/// threshold buffer.
 pub fn set_postpone_deadline(env: &Env, event_id: &Symbol, deadline_ledger: u32) {
     let key = DataKey::PostponeDeadline(event_id.clone());
     env.storage().persistent().set(&key, &deadline_ledger);
+    let current = env.ledger().sequence();
+    let window = deadline_ledger.saturating_sub(current);
+    let extend_to = window.saturating_add(TTL_THRESHOLD);
     env.storage()
         .persistent()
-        .extend_ttl(&key, TTL_THRESHOLD, TTL_BUMP);
+        .extend_ttl(&key, TTL_THRESHOLD, extend_to.max(TTL_BUMP));
 }
 
 /// Read the refund-choice deadline (ledger sequence) for a postponed event.

--- a/contracts/payments/src/types.rs
+++ b/contracts/payments/src/types.rs
@@ -8,6 +8,7 @@ pub enum EventStatus {
     Active = 1,
     Completed = 2,
     Cancelled = 3,
+    Postponed = 4,
 }
 
 #[contracttype]

--- a/contracts/ticket/src/lib.rs
+++ b/contracts/ticket/src/lib.rs
@@ -12,8 +12,11 @@ mod test;
 
 use crate::errors::TicketError;
 use crate::storage::DataKey;
-use crate::types::{Ticket, TicketStatus};
 use soroban_sdk::{contract, contractimpl, vec, xdr::ToXdr, Address, BytesN, Env, Symbol, Vec};
+
+// Re-export public types so dependent contracts (e.g. the event contract) can name
+// `ticket_contract::Ticket` / `ticket_contract::TicketStatus` when consuming the client.
+pub use crate::types::{Ticket, TicketStatus};
 
 #[contract]
 pub struct TicketContract;


### PR DESCRIPTION
## Linked issue
Closes #123

## Change type
- [x] New contract entrypoint
- [x] Struct / storage change
- [x] Event / emission change
- [x] Cross-contract interface change
- [ ] Bug fix
- [ ] Refactor / deprecation
- [ ] Test-only change
- [x] Documentation change

## Cross-contract impact

- [x] Yes — new event → payments calls:
  - `event::postpone_event` → `payments::postpone_event(event_id, organizer, choice_deadline_ledger)` — freezes escrow, records deadline.
  - `event::finalize_postponement` → `payments::sync_event_config(... new ledgers ...)` then `payments::resume_event(event_id, organizer)` — pushes the new schedule, flips status back to `Active`.
  - Both new payments entrypoints gate on `event_contract.require_auth()` + organizer match, mirroring the existing `cancel_event` pattern.
  - **No existing signature changed**, so no existing caller required updating. No hardcoded defaults introduced on cross-contract calls.

---

**New tests added:**

| Test name | What it actually proves |
|-----------|------------------------|
| `test_postpone_full_refund_and_resume` | End-to-end: 2 paid attendees → postpone → attendee A opt-out refund. Asserts A's balance fully restored, escrow + revenue down by exactly one ticket, and reads `PaymentStatus::Refunded` from storage. Then finalizes, completes, withdraws — organizer receives **only** the non-refunded ticket. |
| `test_postponed_event_blocks_all_withdrawals` | Both `event::withdraw_revenue` and direct `payments::withdraw` error while `Postponed`. |
| `test_postponement_refund_after_window_closed_fails` | Past the deadline → `PostponementWindowClosed`. |
| `test_postponement_refund_rejects_non_owner` | Non-owner calling with someone else's ticket → `Unauthorized`. |
| `test_postpone_active_event_opens_window` | Happy path; `PostponementInfo` fields + `postpone_count` correct. |
| `test_postpone_rejects_non_active_states` / `_rejects_cancelled` | `Upcoming`/`Completed`/`Cancelled` → `InvalidStatusTransition`. |
| `test_postpone_rejects_short_window` | Window < 72h → `PostponementWindowTooShort`. |
| `test_postpone_rejects_new_date_inside_window` | New date ≤ deadline → `InvalidPostponementDate`. |
| `test_postpone_requires_organizer` | Non-organizer → `Unauthorized`. |
| `test_finalize_before_window_closes_fails` | Early finalize → `PostponementWindowOpen`. |
| `test_finalize_requires_postponed_state` | Finalize on non-postponed → `EventNotPostponed`. |
| `test_finalize_resumes_active_and_shifts_schedule` | Returns to `Active`; start/end ledgers shifted with duration preserved. |
| `test_postpone_count_capped` | 3rd postponement → `MaxPostponementsReached`. |
| `test_cancel_allowed_from_postponed` | Escape hatch: `Postponed → Cancelled` allowed. |
| `test_withdraw_revenue_blocked_while_postponed` | Event-side withdraw blocked. |

**Edge cases covered:**
- [x] Happy path for each new entrypoint
- [x] Rejection of invalid state transitions
- [x] Boundary values (window = MIN−1, new date = deadline exactly, postpone count at the cap)
- [x] The specific abuse scenario from the linked issue (indefinite postponement)

**Test count:** 16 new (12 event-unit + 4 cross-contract integration); **221 total pass** across the workspace.

---




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added event postponement for active events, including a holder refund-choice window and an opt-out holder refund flow.
  * Added organizer controls to postpone and later finalize/resume events back to Active after the window closes.
  * Enhanced payments to support postponed-event lifecycle, including freezing withdrawals and handling holder postponement refunds.
  * Added event log emissions for postponed and resumed status changes.
* **Bug Fixes**
  * Strengthened validation and lifecycle gating with postponement-specific error codes.
* **Tests**
  * Added integration and lifecycle constraint tests for refund timing, authorization, event-scoped refunds, and max postponement limits.
* **Documentation**
  * Updated README lifecycle/cancellation documentation to include the Postponed state and new transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->