### PR TITLE
feat: multi-organizer revenue split and co-host wallet management

### DIFF
--- a/contracts/event/src/errors.rs
+++ b/contracts/event/src/errors.rs
@@ -30,4 +30,7 @@ pub enum EventError {
     PrivacyViolation = 24,
     ClaimLimitExceeded = 25,
     ClaimCooldownActive = 26,
+    /// Revenue split is malformed: wrong basis-point sum, too many recipients,
+    /// a zero/duplicate recipient, or index 0 is not the primary organizer.
+    InvalidRevenueSplit = 27,
 }

--- a/contracts/event/src/integration_tests.rs
+++ b/contracts/event/src/integration_tests.rs
@@ -1,7 +1,7 @@
 use crate::types::{CreateEventParams, EventStatus, PrivacyLevel, TicketTierParams};
-use crate::{EventContract, EventContractClient};
+use crate::{EventContract, EventContractClient, EventError};
 use soroban_sdk::testutils::{Address as _, Ledger};
-use soroban_sdk::{token, Address, BytesN, Env, String, Symbol};
+use soroban_sdk::{token, vec, Address, BytesN, Env, String, Symbol, Vec};
 
 fn setup_env() -> Env {
     let env = Env::default();
@@ -42,6 +42,7 @@ fn create_active_event(
         event_start_ledger: 0,
         event_end_ledger: 1000,
         withdrawal_delay_ledgers: 17280,
+        revenue_splits: soroban_sdk::Vec::new(env),
     };
 
     client.create_event(&params);
@@ -382,4 +383,216 @@ fn test_withdraw_revenue_integration() {
 
     assert_eq!(token_client.balance(&organizer), price);
     assert_eq!(token_client.balance(&payments_contract_id), 0);
+}
+
+// ── Multi-organizer revenue split integration (#122) ──────────────────────────
+
+struct SplitWorld<'a> {
+    env: &'a Env,
+    event_client: EventContractClient<'a>,
+    payments_client: payments_contract::PaymentsContractClient<'a>,
+    payments_contract_id: Address,
+    token_admin_client: token::StellarAssetClient<'a>,
+    token_client: token::Client<'a>,
+    token_address: Address,
+    organizer: Address,
+}
+
+fn setup_split_world(env: &Env) -> SplitWorld<'_> {
+    let organizer = Address::generate(env);
+
+    let event_contract_id = env.register(EventContract, ());
+    let event_client = EventContractClient::new(env, &event_contract_id);
+    let ticket_contract_id = env.register(ticket_contract::TicketContract, ());
+    let payments_contract_id = env.register(payments_contract::PaymentsContract, ());
+    let payments_client =
+        payments_contract::PaymentsContractClient::new(env, &payments_contract_id);
+
+    let token_admin = Address::generate(env);
+    let token_address = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let token_admin_client = token::StellarAssetClient::new(env, &token_address);
+    let token_client = token::Client::new(env, &token_address);
+
+    let platform_wallet = Address::generate(env);
+    payments_client.initialize(
+        &organizer,
+        &token_address,
+        &0,
+        &platform_wallet,
+        &event_contract_id,
+    );
+    event_client.initialize(&organizer, &ticket_contract_id, &payments_contract_id);
+
+    SplitWorld {
+        env,
+        event_client,
+        payments_client,
+        payments_contract_id,
+        token_admin_client,
+        token_client,
+        token_address,
+        organizer,
+    }
+}
+
+fn create_split_event(
+    w: &SplitWorld,
+    event_id: &Symbol,
+    splits: Vec<(Address, u32)>,
+) -> Result<(), EventError> {
+    let params = CreateEventParams {
+        organizer: w.organizer.clone(),
+        payout_token: w.token_address.clone(),
+        event_id: event_id.clone(),
+        name: String::from_str(w.env, "Split Event"),
+        description: String::from_str(w.env, "Co-hosted"),
+        venue: String::from_str(w.env, "Main Hall"),
+        event_date: w.env.ledger().timestamp() + 86_401,
+        initial_tiers: vec![
+            w.env,
+            TicketTierParams {
+                name: String::from_str(w.env, "General"),
+                price: 100_000_000,
+                capacity: 10,
+            },
+        ],
+        allow_anonymous: true,
+        requires_verification: false,
+        privacy_level: PrivacyLevel::Standard,
+        max_tickets_per_user: 0,
+        event_start_ledger: 0,
+        event_end_ledger: 1000,
+        withdrawal_delay_ledgers: 17280,
+        revenue_splits: splits,
+    };
+    w.event_client
+        .try_create_event(&params)
+        .map(|_| ())
+        .map_err(|e| e.unwrap())
+}
+
+#[test]
+fn test_event_split_end_to_end_distribution() {
+    let env = setup_env();
+    let w = setup_split_world(&env);
+    let cohost = Address::generate(&env);
+    let attendee = Address::generate(&env);
+    let event_id = Symbol::new(&env, "evt_split_1");
+
+    let splits: Vec<(Address, u32)> = vec![
+        &env,
+        (w.organizer.clone(), 7000u32),
+        (cohost.clone(), 3000u32),
+    ];
+    create_split_event(&w, &event_id, splits).unwrap();
+
+    // The split is visible both on the event and synced to payments.
+    let on_event = w.event_client.get_revenue_splits(&event_id);
+    assert_eq!(on_event.len(), 2);
+    let on_payments = w.payments_client.get_revenue_splits(&event_id);
+    assert_eq!(on_payments.len(), 2);
+
+    w.event_client
+        .update_event_status(&w.organizer, &event_id, &EventStatus::Active);
+
+    let price = 100_000_000i128;
+    w.token_admin_client.mint(&attendee, &price);
+    w.event_client
+        .register_for_event(&1, &attendee, &event_id, &0, &false, &None);
+    assert_eq!(w.token_client.balance(&w.payments_contract_id), price);
+
+    // Mark completed on both contracts and pass the withdrawal delay.
+    w.event_client
+        .update_event_status(&w.organizer, &event_id, &EventStatus::Completed);
+    w.payments_client.set_event_status(
+        &w.organizer,
+        &event_id,
+        &payments_contract::EventStatus::Completed,
+    );
+    env.ledger().with_mut(|li| li.sequence_number = 20_000);
+
+    // Each recipient withdraws independently through the event front door.
+    w.event_client.withdraw_split(&cohost, &event_id);
+    w.event_client.withdraw_split(&w.organizer, &event_id);
+
+    assert_eq!(w.token_client.balance(&cohost), 30_000_000);
+    assert_eq!(w.token_client.balance(&w.organizer), 70_000_000);
+    assert_eq!(w.token_client.balance(&w.payments_contract_id), 0);
+}
+
+#[test]
+fn test_event_rejects_invalid_split_configurations() {
+    let env = setup_env();
+    let w = setup_split_world(&env);
+    let cohost = Address::generate(&env);
+
+    // Index 0 is not the primary organizer.
+    let wrong_primary: Vec<(Address, u32)> = vec![
+        &env,
+        (cohost.clone(), 6000u32),
+        (w.organizer.clone(), 4000u32),
+    ];
+    assert_eq!(
+        create_split_event(&w, &Symbol::new(&env, "bad1"), wrong_primary),
+        Err(EventError::InvalidRevenueSplit)
+    );
+
+    // Basis points do not sum to 10000.
+    let bad_sum: Vec<(Address, u32)> = vec![
+        &env,
+        (w.organizer.clone(), 6000u32),
+        (cohost.clone(), 3000u32),
+    ];
+    assert_eq!(
+        create_split_event(&w, &Symbol::new(&env, "bad2"), bad_sum),
+        Err(EventError::InvalidRevenueSplit)
+    );
+}
+
+#[test]
+fn test_event_flag_cohost_through_front_door() {
+    let env = setup_env();
+    let w = setup_split_world(&env);
+    let cohost = Address::generate(&env);
+    let attendee = Address::generate(&env);
+    let event_id = Symbol::new(&env, "evt_split_2");
+
+    let splits: Vec<(Address, u32)> = vec![
+        &env,
+        (w.organizer.clone(), 6000u32),
+        (cohost.clone(), 4000u32),
+    ];
+    create_split_event(&w, &event_id, splits).unwrap();
+    w.event_client
+        .update_event_status(&w.organizer, &event_id, &EventStatus::Active);
+
+    let price = 100_000_000i128;
+    w.token_admin_client.mint(&attendee, &price);
+    w.event_client
+        .register_for_event(&1, &attendee, &event_id, &0, &false, &None);
+
+    w.event_client
+        .update_event_status(&w.organizer, &event_id, &EventStatus::Completed);
+    w.payments_client.set_event_status(
+        &w.organizer,
+        &event_id,
+        &payments_contract::EventStatus::Completed,
+    );
+    env.ledger().with_mut(|li| li.sequence_number = 20_000);
+
+    // Primary organizer flags the co-host wallet through the event contract.
+    w.event_client.flag_cohost(&w.organizer, &event_id, &cohost);
+    assert!(w.payments_client.is_recipient_flagged(&event_id, &cohost));
+
+    // The flagged co-host cannot withdraw; the primary still can.
+    assert!(w
+        .event_client
+        .try_withdraw_split(&cohost, &event_id)
+        .is_err());
+    w.event_client.withdraw_split(&w.organizer, &event_id);
+    assert_eq!(w.token_client.balance(&w.organizer), 60_000_000);
+    // Co-host's share remains escrowed.
+    assert_eq!(w.token_client.balance(&w.payments_contract_id), 40_000_000);
 }

--- a/contracts/event/src/lib.rs
+++ b/contracts/event/src/lib.rs
@@ -77,6 +77,10 @@ impl EventContract {
             return Err(EventError::InvalidInput);
         }
 
+        // Validate the revenue split if one was provided. An empty split keeps the
+        // legacy single-organizer payout behaviour.
+        validate_revenue_splits(&params.revenue_splits, &params.organizer)?;
+
         let mut tiers = soroban_sdk::Vec::new(&env);
         let mut max_supply = 0u32;
         for (current_tier_id, tier_param) in params.initial_tiers.iter().enumerate() {
@@ -138,6 +142,7 @@ impl EventContract {
             event_start_ledger: params.event_start_ledger,
             event_end_ledger: params.event_end_ledger,
             withdrawal_delay_ledgers: params.withdrawal_delay_ledgers,
+            revenue_splits: params.revenue_splits.clone(),
         };
 
         save_event(&env, &params.event_id, &event);
@@ -160,6 +165,15 @@ impl EventContract {
                 &event.event_end_ledger,
                 &event.withdrawal_delay_ledgers,
             );
+            // Register the (immutable) revenue split alongside the event config so
+            // the payments contract can pay each recipient independently.
+            if !params.revenue_splits.is_empty() {
+                payments_client.sync_revenue_splits(
+                    &env.current_contract_address(),
+                    &params.event_id,
+                    &params.revenue_splits,
+                );
+            }
         }
         let privacy = storage::get_event_privacy(&env, &params.event_id);
         emit_event_created(&env, &params, &privacy);
@@ -890,6 +904,104 @@ impl EventContract {
 
         Ok(new_version)
     }
+
+    /// Get the configured revenue split for an event as `(Address, basis_points)`.
+    /// An empty result means the event uses the legacy single-organizer payout.
+    pub fn get_revenue_splits(
+        env: Env,
+        event_id: Symbol,
+    ) -> Result<soroban_sdk::Vec<(Address, u32)>, EventError> {
+        let event = storage::get_event(&env, &event_id)?;
+        Ok(event.revenue_splits)
+    }
+
+    /// Withdraw the caller's allocated share of a split event's revenue.
+    /// Proxies to the payments contract, which performs the actual settlement and
+    /// transfer. Any configured recipient may call this independently.
+    pub fn withdraw_split(
+        env: Env,
+        recipient: Address,
+        event_id: Symbol,
+    ) -> Result<(), EventError> {
+        recipient.require_auth();
+        storage::get_event(&env, &event_id)?;
+
+        let payments_contract = storage::get_payments_contract(&env)?;
+        let payments_client = PaymentsContractClient::new(&env, &payments_contract);
+        payments_client.withdraw_split(&recipient, &event_id);
+
+        Ok(())
+    }
+
+    /// Flag a co-host wallet as compromised. Only the primary organizer (the
+    /// event organizer / split index 0) may call this. Proxies to the payments
+    /// contract, which freezes the flagged recipient's share in escrow.
+    pub fn flag_cohost(
+        env: Env,
+        primary_organizer: Address,
+        event_id: Symbol,
+        recipient: Address,
+    ) -> Result<(), EventError> {
+        primary_organizer.require_auth();
+
+        let event = storage::get_event(&env, &event_id)?;
+        // The primary organizer always retains admin rights regardless of split
+        // percentage: the event's organizer is the split's index-0 recipient.
+        if event.organizer != primary_organizer {
+            return Err(EventError::Unauthorized);
+        }
+
+        let payments_contract = storage::get_payments_contract(&env)?;
+        let payments_client = PaymentsContractClient::new(&env, &payments_contract);
+        payments_client.flag_cohost(&primary_organizer, &event_id, &recipient);
+
+        Ok(())
+    }
+}
+
+/// Validate a revenue split. An empty split is allowed (legacy single-organizer
+/// payout). When non-empty: 1–5 recipients, basis points summing to exactly
+/// 10000, no zero allocations, no duplicate recipients, and index 0 must be the
+/// primary organizer.
+fn validate_revenue_splits(
+    splits: &soroban_sdk::Vec<(Address, u32)>,
+    organizer: &Address,
+) -> Result<(), EventError> {
+    let len = splits.len();
+    if len == 0 {
+        return Ok(());
+    }
+    if len > 5 {
+        return Err(EventError::InvalidRevenueSplit);
+    }
+
+    let (first, _) = splits.get(0).ok_or(EventError::InvalidRevenueSplit)?;
+    if first != *organizer {
+        return Err(EventError::InvalidRevenueSplit);
+    }
+
+    let mut total: u32 = 0;
+    for i in 0..len {
+        let (recipient, bps) = splits.get(i).ok_or(EventError::InvalidRevenueSplit)?;
+        if bps == 0 {
+            return Err(EventError::InvalidRevenueSplit);
+        }
+        total = total
+            .checked_add(bps)
+            .ok_or(EventError::InvalidRevenueSplit)?;
+        for j in 0..i {
+            let (other, _) = splits.get(j).ok_or(EventError::InvalidRevenueSplit)?;
+            if other == recipient {
+                return Err(EventError::InvalidRevenueSplit);
+            }
+        }
+    }
+
+    if total != 10_000 {
+        return Err(EventError::InvalidRevenueSplit);
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/contracts/event/src/test.rs
+++ b/contracts/event/src/test.rs
@@ -83,6 +83,7 @@ fn test_create_event_duplicate_fails() {
         event_start_ledger: 0,
         event_end_ledger: 1000,
         withdrawal_delay_ledgers: 17280,
+        revenue_splits: soroban_sdk::Vec::new(&env),
     };
 
     // First creation succeeds
@@ -105,6 +106,7 @@ fn test_create_event_duplicate_fails() {
         event_start_ledger: 0,
         event_end_ledger: 1000,
         withdrawal_delay_ledgers: 17280,
+        revenue_splits: soroban_sdk::Vec::new(&env),
     };
     let result = client.try_create_event(&params_dup);
     assert_eq!(result.err(), Some(Ok(EventError::EventAlreadyExists)));
@@ -140,6 +142,7 @@ fn test_create_event_invalid_tickets_fails() {
         event_start_ledger: 0,
         event_end_ledger: 1000,
         withdrawal_delay_ledgers: 17280,
+        revenue_splits: soroban_sdk::Vec::new(&env),
     };
 
     let result = client.try_create_event(&params);
@@ -176,6 +179,7 @@ fn test_create_event_too_many_tickets_fails() {
         event_start_ledger: 0,
         event_end_ledger: 1000,
         withdrawal_delay_ledgers: 17280,
+        revenue_splits: soroban_sdk::Vec::new(&env),
     };
 
     let result = client.try_create_event(&params);
@@ -212,6 +216,7 @@ fn test_create_event_past_date_fails() {
         event_start_ledger: 0,
         event_end_ledger: 1000,
         withdrawal_delay_ledgers: 17280,
+        revenue_splits: soroban_sdk::Vec::new(&env),
     };
 
     let result = client.try_create_event(&params);
@@ -248,6 +253,7 @@ fn test_create_event_date_less_than_24h_fails() {
         event_start_ledger: 0,
         event_end_ledger: 1000,
         withdrawal_delay_ledgers: 17280,
+        revenue_splits: soroban_sdk::Vec::new(&env),
     };
 
     let result = client.try_create_event(&params);
@@ -284,6 +290,7 @@ fn test_create_event_negative_price_fails() {
         event_start_ledger: 0,
         event_end_ledger: 1000,
         withdrawal_delay_ledgers: 17280,
+        revenue_splits: soroban_sdk::Vec::new(&env),
     };
 
     let result = client.try_create_event(&params);
@@ -320,6 +327,7 @@ fn test_create_event_empty_name_fails() {
         event_start_ledger: 0,
         event_end_ledger: 1000,
         withdrawal_delay_ledgers: 17280,
+        revenue_splits: soroban_sdk::Vec::new(&env),
     };
 
     let result = client.try_create_event(&params);
@@ -356,6 +364,7 @@ fn test_create_event_empty_venue_fails() {
         event_start_ledger: 0,
         event_end_ledger: 1000,
         withdrawal_delay_ledgers: 17280,
+        revenue_splits: soroban_sdk::Vec::new(&env),
     };
 
     let result = client.try_create_event(&params);
@@ -768,6 +777,7 @@ fn test_register_for_event_sold_out_fails() {
         event_start_ledger: 0,
         event_end_ledger: 1000,
         withdrawal_delay_ledgers: 17280,
+        revenue_splits: soroban_sdk::Vec::new(&env),
     };
     client.create_event(&params);
     client.update_event_status(&organizer, &event_id, &EventStatus::Active);
@@ -887,6 +897,7 @@ fn setup_event_with_payout_token(
         event_start_ledger: 0,
         event_end_ledger: 1000,
         withdrawal_delay_ledgers: 17280,
+        revenue_splits: soroban_sdk::Vec::new(env),
     };
 
     client.create_event(&params);
@@ -1018,6 +1029,7 @@ fn test_reserve_expire_and_available_again() {
         event_start_ledger: 0,
         event_end_ledger: 1000,
         withdrawal_delay_ledgers: 17280,
+        revenue_splits: soroban_sdk::Vec::new(&env),
     };
     client.create_event(&params);
     client.update_event_status(&organizer, &event_id, &EventStatus::Active);
@@ -1220,6 +1232,7 @@ fn test_create_event_minimum_withdrawal_delay_enforced() {
         event_start_ledger: 100,
         event_end_ledger: 200,
         withdrawal_delay_ledgers: 0, // Below minimum!
+        revenue_splits: soroban_sdk::Vec::new(&env),
     };
 
     let result = client.try_create_event(&params);

--- a/contracts/event/src/test_claims.rs
+++ b/contracts/event/src/test_claims.rs
@@ -63,6 +63,7 @@ fn create_free_event(
         event_start_ledger: 0,
         event_end_ledger: 1000,
         withdrawal_delay_ledgers: 17280,
+        revenue_splits: soroban_sdk::Vec::new(env),
     };
     client.create_event(&params);
     client.update_event_status(organizer, &event_id, &EventStatus::Active);
@@ -100,6 +101,7 @@ fn create_paid_event(
         event_start_ledger: 0,
         event_end_ledger: 1000,
         withdrawal_delay_ledgers: 17280,
+        revenue_splits: soroban_sdk::Vec::new(env),
     };
     client.create_event(&params);
     client.update_event_status(organizer, &event_id, &EventStatus::Active);

--- a/contracts/event/src/test_privacy.rs
+++ b/contracts/event/src/test_privacy.rs
@@ -43,6 +43,7 @@ fn create_event_with_privacy(
         event_start_ledger: 0,
         event_end_ledger: 1000,
         withdrawal_delay_ledgers: 17280,
+        revenue_splits: soroban_sdk::Vec::new(env),
     };
     client.create_event(&params);
 }

--- a/contracts/event/src/types.rs
+++ b/contracts/event/src/types.rs
@@ -51,6 +51,10 @@ pub struct Event {
     pub event_start_ledger: u32,
     pub event_end_ledger: u32,
     pub withdrawal_delay_ledgers: u32,
+    /// Revenue split recipients as `(Address, basis_points)`. Empty means the
+    /// legacy single-organizer payout. When set, index 0 is the primary
+    /// organizer and the basis points sum to 10000.
+    pub revenue_splits: Vec<(Address, u32)>,
 }
 
 #[contracttype]
@@ -71,6 +75,10 @@ pub struct CreateEventParams {
     pub event_start_ledger: u32,
     pub event_end_ledger: u32,
     pub withdrawal_delay_ledgers: u32,
+    /// Optional revenue split as `(Address, basis_points)`. Leave empty for the
+    /// legacy single-organizer payout. When provided: 1–5 recipients, basis
+    /// points summing to 10000, index 0 must equal `organizer`, no duplicates.
+    pub revenue_splits: Vec<(Address, u32)>,
 }
 
 #[contracttype]

--- a/contracts/payments/src/errors.rs
+++ b/contracts/payments/src/errors.rs
@@ -37,4 +37,17 @@ pub enum PaymentError {
     ContractPaused = 31,
     /// Token transfer failed; no state has been modified
     TransferFailed = 32,
+    /// Revenue split configuration is invalid (bad sum, too many recipients,
+    /// duplicate or empty recipient, or an attempt to mutate an existing config).
+    InvalidSplitConfig = 33,
+    /// No revenue split has been configured for this event.
+    SplitsNotConfigured = 34,
+    /// The caller is not one of the configured split recipients.
+    NotASplitRecipient = 35,
+    /// This recipient has already withdrawn (or had reassigned) its split share.
+    SplitAlreadyWithdrawn = 36,
+    /// The recipient's share is frozen because the wallet has been flagged.
+    RecipientFlagged = 37,
+    /// The recipient is not currently flagged.
+    RecipientNotFlagged = 38,
 }

--- a/contracts/payments/src/events.rs
+++ b/contracts/payments/src/events.rs
@@ -296,7 +296,7 @@ pub fn emit_cohost_flagged(env: &Env, event_id: Symbol, recipient: Address, flag
     .publish(env);
 }
 
-#[contractevent(data_format = "vec", topics = ["flag_resolved"])]
+#[contractevent(data_format = "vec", topics = ["flagged_share_resolved"])]
 pub struct FlaggedShareResolved {
     pub event_type: Symbol,
     pub event_id: Symbol,

--- a/contracts/payments/src/events.rs
+++ b/contracts/payments/src/events.rs
@@ -252,3 +252,52 @@ pub fn emit_platform_revenue_withdrawn(
     }
     .publish(env);
 }
+
+#[contractevent(data_format = "vec", topics = ["cohost_flagged"])]
+pub struct CohostFlagged {
+    pub event_type: Symbol,
+    pub event_id: Symbol,
+    pub recipient: Address,
+    pub flagged_by: Address,
+    pub flagged_at: u64,
+}
+
+pub fn emit_cohost_flagged(env: &Env, event_id: Symbol, recipient: Address, flagged_by: Address) {
+    CohostFlagged {
+        event_type: event_type(env, "cohost_flagged"),
+        event_id,
+        recipient,
+        flagged_by,
+        flagged_at: env.ledger().timestamp(),
+    }
+    .publish(env);
+}
+
+#[contractevent(data_format = "vec", topics = ["flag_resolved"])]
+pub struct FlaggedShareResolved {
+    pub event_type: Symbol,
+    pub event_id: Symbol,
+    pub recipient: Address,
+    /// true => released to recipient, false => reassigned to primary organizer
+    pub released_to_recipient: bool,
+    pub amount: i128,
+    pub resolved_at: u64,
+}
+
+pub fn emit_flagged_share_resolved(
+    env: &Env,
+    event_id: Symbol,
+    recipient: Address,
+    released_to_recipient: bool,
+    amount: i128,
+) {
+    FlaggedShareResolved {
+        event_type: event_type(env, "flagged_share_resolved"),
+        event_id,
+        recipient,
+        released_to_recipient,
+        amount,
+        resolved_at: env.ledger().timestamp(),
+    }
+    .publish(env);
+}

--- a/contracts/payments/src/lib.rs
+++ b/contracts/payments/src/lib.rs
@@ -279,6 +279,162 @@ fn collect_held_payments_for_token(
     Ok((total, payments))
 }
 
+/// Reject legacy single-organizer withdrawal paths for events that carry a
+/// revenue split. Split events must settle through `withdraw_split` so that the
+/// platform fee is deducted once and each recipient is paid exactly their share.
+fn ensure_no_splits(env: &Env, event_id: &Symbol) -> Result<(), PaymentError> {
+    if storage::has_splits(env, event_id) {
+        return Err(PaymentError::InvalidSplitConfig);
+    }
+    Ok(())
+}
+
+/// Look up a recipient's basis-point allocation within a split configuration.
+fn find_split_bps(splits: &soroban_sdk::Vec<RevenueSplit>, who: &Address) -> Option<u32> {
+    for i in 0..splits.len() {
+        if let Some(split) = splits.get(i) {
+            if split.recipient == *who {
+                return Some(split.basis_points);
+            }
+        }
+    }
+    None
+}
+
+/// Compute a recipient's payout from the frozen net-distributable amount.
+///
+/// Non-primary recipients receive `floor(net * bps / 10000)`. The primary
+/// organizer (index 0) receives the remainder, so integer-division dust is never
+/// stranded and the sum of all shares always equals `net`.
+fn recipient_share(splits: &soroban_sdk::Vec<RevenueSplit>, who: &Address, net: i128) -> i128 {
+    let primary = match splits.get(0) {
+        Some(s) => s.recipient,
+        None => return 0,
+    };
+
+    if *who == primary {
+        let mut others_total: i128 = 0;
+        for i in 1..splits.len() {
+            if let Some(split) = splits.get(i) {
+                others_total += net * (split.basis_points as i128) / 10_000;
+            }
+        }
+        net - others_total
+    } else {
+        match find_split_bps(splits, who) {
+            Some(bps) => net * (bps as i128) / 10_000,
+            None => 0,
+        }
+    }
+}
+
+/// Settle a split event exactly once, returning the frozen net-distributable
+/// snapshot. Mirrors the status/timing rules of [`PaymentsContract::withdraw`]:
+/// completed events honour the withdrawal delay, cancelled events honour the
+/// dispute window and the time-based withdrawable ratio. The platform fee is
+/// deducted here, before any recipient share is computed.
+fn ensure_split_settled(env: &Env, event_id: &Symbol) -> Result<SplitSettlement, PaymentError> {
+    if let Some(settlement) = storage::get_split_settlement(env, event_id) {
+        return Ok(settlement);
+    }
+
+    let config = storage::get_event_config(env, event_id).ok_or(PaymentError::InvalidOrganizer)?;
+    let mut withdrawable_ratio_bps = 10_000u32;
+    let current_ledger = env.ledger().sequence();
+
+    match storage::get_event_status(env, event_id) {
+        Some(EventStatus::Completed) => {
+            let unlock_ledger = config.event_end_ledger
+                + config.withdrawal_delay_ledgers
+                + config.admin_delay_extension_ledgers;
+            if current_ledger < unlock_ledger {
+                return Err(PaymentError::EscrowNotExpired);
+            }
+        }
+        Some(EventStatus::Cancelled) => {
+            if let Some(cancel_ledger) = config.cancel_ledger {
+                if current_ledger < cancel_ledger + MIN_DISPUTE_WINDOW_LEDGERS {
+                    return Err(PaymentError::EscrowNotExpired);
+                }
+            } else {
+                return Err(PaymentError::EventNotCompleted);
+            }
+
+            match config.withdrawable_ratio_bps {
+                Some(0) => return Err(PaymentError::NoRevenue),
+                Some(ratio) => withdrawable_ratio_bps = ratio,
+                None => return Err(PaymentError::EventNotCompleted),
+            }
+        }
+        _ => return Err(PaymentError::EventNotCompleted),
+    }
+
+    validate_revenue_invariant(env, event_id)?;
+
+    let payout_token = storage::get_event_payout_token(env, event_id)?;
+    let (total, payments_to_release) =
+        collect_held_payments_for_token(env, event_id, &payout_token)?;
+    if total <= 0 {
+        return Err(PaymentError::NoRevenue);
+    }
+
+    let total_to_withdraw = total * (withdrawable_ratio_bps as i128) / 10_000;
+    if total_to_withdraw <= 0 {
+        return Err(PaymentError::NoRevenue);
+    }
+
+    let fee_bps = storage::get_platform_fee_bps(env) as i128;
+    let fee_amount = total_to_withdraw * fee_bps / 10_000;
+    let net = total_to_withdraw - fee_amount;
+    if net <= 0 {
+        return Err(PaymentError::NoRevenue);
+    }
+
+    // Move the distributable funds out of the held-payment accounting. For a full
+    // (non-cancelled) settlement we release every held payment; for a partial
+    // (cancelled) settlement we only reduce the revenue counters and leave the
+    // remainder Held so attendees can still claim their pro-rata refunds.
+    if withdrawable_ratio_bps == 10_000 {
+        for i in 0..payments_to_release.len() {
+            let mut payment = payments_to_release
+                .get(i)
+                .ok_or(PaymentError::PaymentNotFound)?;
+            payment.status = PaymentStatus::Released;
+            storage::update_payment(env, &payment)?;
+        }
+        storage::set_event_token_revenue(env, event_id, &payout_token, 0);
+    } else {
+        let current_token_rev = storage::get_event_token_revenue(env, event_id, &payout_token);
+        storage::set_event_token_revenue(
+            env,
+            event_id,
+            &payout_token,
+            current_token_rev - total_to_withdraw,
+        );
+        let current_rev = storage::get_event_revenue(env, event_id);
+        storage::set_event_revenue(env, event_id, current_rev - total_to_withdraw);
+    }
+
+    if fee_amount > 0 {
+        storage::add_platform_revenue(env, event_id, fee_amount);
+        events::emit_platform_fee_collected(
+            env,
+            event_id.clone(),
+            fee_amount,
+            net,
+            payout_token.clone(),
+        );
+    }
+
+    let settlement = SplitSettlement {
+        token: payout_token,
+        net_distributable: net,
+    };
+    storage::set_split_settlement(env, event_id, &settlement);
+
+    Ok(settlement)
+}
+
 #[contractimpl]
 impl PaymentsContract {
     /// Initialize the contract with an admin address, accepted token address,
@@ -588,6 +744,7 @@ impl PaymentsContract {
     pub fn withdraw(env: Env, organizer: Address, event_id: Symbol) -> Result<(), PaymentError> {
         require_not_paused(&env)?;
         organizer.require_auth();
+        ensure_no_splits(&env, &event_id)?;
 
         let stored_organizer = storage::get_event_organizer(&env, &event_id)?;
         if organizer != stored_organizer {
@@ -913,6 +1070,7 @@ impl PaymentsContract {
     /// Idempotent: calling after already released returns EscrowAlreadyReleased.
     pub fn release_if_expired(env: Env, event_id: Symbol) -> Result<(), PaymentError> {
         require_not_paused(&env)?;
+        ensure_no_splits(&env, &event_id)?;
         let mut meta = storage::get_escrow_meta(&env, &event_id)?;
 
         if meta.auto_released {
@@ -983,6 +1141,7 @@ impl PaymentsContract {
         require_not_paused(&env)?;
         let admin = storage::get_admin(&env)?;
         admin.require_auth();
+        ensure_no_splits(&env, &event_id)?;
 
         validate_revenue_invariant(&env, &event_id)?;
 
@@ -1211,6 +1370,7 @@ impl PaymentsContract {
     ) -> Result<(), PaymentError> {
         require_not_paused(&env)?;
         organizer.require_auth();
+        ensure_no_splits(&env, &event_id)?;
 
         match storage::get_event_status(&env, &event_id) {
             Some(EventStatus::Completed) => {}
@@ -1294,6 +1454,7 @@ impl PaymentsContract {
     ) -> Result<(), PaymentError> {
         require_not_paused(&env)?;
         organizer.require_auth();
+        ensure_no_splits(&env, &event_id)?;
 
         match storage::get_event_status(&env, &event_id) {
             Some(EventStatus::Completed) => {}
@@ -1365,9 +1526,260 @@ impl PaymentsContract {
 
         Ok(())
     }
+
+    // ── Revenue splits & co-host wallet management ────────────────────────────
+
+    /// Register the revenue split for an event. Callable only by the linked event
+    /// contract, and only once — splits are immutable for the life of the event.
+    ///
+    /// `splits` is `Vec<(Address, u32)>` where the `u32` is basis points. The
+    /// basis points must sum to exactly 10000, there must be between 1 and 5
+    /// recipients, no zero allocations, and no duplicate recipients. Index 0 is
+    /// the primary organizer.
+    pub fn sync_revenue_splits(
+        env: Env,
+        event_contract: Address,
+        event_id: Symbol,
+        splits: soroban_sdk::Vec<(Address, u32)>,
+    ) -> Result<(), PaymentError> {
+        require_not_paused(&env)?;
+        if event_contract != storage::get_event_contract(&env)? {
+            return Err(PaymentError::Unauthorized);
+        }
+        event_contract.require_auth();
+
+        // Immutable: never overwrite an existing configuration.
+        if storage::has_splits(&env, &event_id) {
+            return Err(PaymentError::InvalidSplitConfig);
+        }
+
+        let len = splits.len();
+        if len == 0 || len > 5 {
+            return Err(PaymentError::InvalidSplitConfig);
+        }
+
+        let mut normalized: soroban_sdk::Vec<RevenueSplit> = soroban_sdk::Vec::new(&env);
+        let mut total: u32 = 0;
+        for i in 0..len {
+            let (recipient, bps) = splits.get(i).ok_or(PaymentError::InvalidSplitConfig)?;
+            if bps == 0 {
+                return Err(PaymentError::InvalidSplitConfig);
+            }
+            total = total
+                .checked_add(bps)
+                .ok_or(PaymentError::InvalidSplitConfig)?;
+            for j in 0..i {
+                let (other, _) = splits.get(j).ok_or(PaymentError::InvalidSplitConfig)?;
+                if other == recipient {
+                    return Err(PaymentError::InvalidSplitConfig);
+                }
+            }
+            normalized.push_back(RevenueSplit {
+                recipient,
+                basis_points: bps,
+            });
+        }
+        if total != 10_000 {
+            return Err(PaymentError::InvalidSplitConfig);
+        }
+
+        storage::set_splits(&env, &event_id, &normalized);
+        Ok(())
+    }
+
+    /// Get the configured revenue split for an event as `Vec<(Address, u32)>`.
+    pub fn get_revenue_splits(env: Env, event_id: Symbol) -> soroban_sdk::Vec<(Address, u32)> {
+        let splits = storage::get_splits(&env, &event_id);
+        let mut out: soroban_sdk::Vec<(Address, u32)> = soroban_sdk::Vec::new(&env);
+        for i in 0..splits.len() {
+            if let Some(split) = splits.get(i) {
+                out.push_back((split.recipient, split.basis_points));
+            }
+        }
+        out
+    }
+
+    /// Withdraw the caller's allocated share of a split event's revenue.
+    ///
+    /// Any configured recipient may call this independently. The first call
+    /// settles the event (deducting the platform fee and freezing the
+    /// net-distributable amount); subsequent calls simply pay out each
+    /// recipient's frozen share. A flagged recipient cannot withdraw.
+    pub fn withdraw_split(
+        env: Env,
+        recipient: Address,
+        event_id: Symbol,
+    ) -> Result<(), PaymentError> {
+        require_not_paused(&env)?;
+        recipient.require_auth();
+
+        let splits = storage::get_splits(&env, &event_id);
+        if splits.is_empty() {
+            return Err(PaymentError::SplitsNotConfigured);
+        }
+        if find_split_bps(&splits, &recipient).is_none() {
+            return Err(PaymentError::NotASplitRecipient);
+        }
+        if storage::is_split_flagged(&env, &event_id, &recipient) {
+            return Err(PaymentError::RecipientFlagged);
+        }
+        if storage::get_split_withdrawn(&env, &event_id, &recipient) > 0 {
+            return Err(PaymentError::SplitAlreadyWithdrawn);
+        }
+
+        let settlement = ensure_split_settled(&env, &event_id)?;
+        let share = recipient_share(&splits, &recipient, settlement.net_distributable);
+        if share <= 0 {
+            return Err(PaymentError::NoRevenue);
+        }
+
+        let token_client = token::Client::new(&env, &settlement.token);
+        token_client.transfer(&env.current_contract_address(), &recipient, &share);
+
+        storage::set_split_withdrawn(&env, &event_id, &recipient, share);
+
+        let record = WithdrawalRecord {
+            amount: share,
+            timestamp: env.ledger().timestamp(),
+            organizer: recipient.clone(),
+        };
+        storage::add_withdrawal_record(&env, &event_id, &record);
+
+        events::emit_revenue_withdrawn(
+            &env,
+            event_id.clone(),
+            recipient.clone(),
+            share,
+            settlement.token,
+            recipient,
+            &storage::get_emission_privacy(&env, &event_id),
+        );
+
+        Ok(())
+    }
+
+    /// Flag a co-host wallet as compromised. Only the primary organizer (split
+    /// index 0) may call this. The flagged recipient's share is frozen in escrow
+    /// and cannot be withdrawn until the dispute is resolved. The primary
+    /// organizer cannot flag itself, and an already-paid recipient cannot be
+    /// flagged.
+    pub fn flag_cohost(
+        env: Env,
+        primary_organizer: Address,
+        event_id: Symbol,
+        recipient: Address,
+    ) -> Result<(), PaymentError> {
+        require_not_paused(&env)?;
+
+        let splits = storage::get_splits(&env, &event_id);
+        if splits.is_empty() {
+            return Err(PaymentError::SplitsNotConfigured);
+        }
+        let primary = splits
+            .get(0)
+            .ok_or(PaymentError::SplitsNotConfigured)?
+            .recipient;
+        if primary_organizer != primary {
+            return Err(PaymentError::Unauthorized);
+        }
+        primary_organizer.require_auth();
+
+        if recipient == primary {
+            return Err(PaymentError::Unauthorized);
+        }
+        if find_split_bps(&splits, &recipient).is_none() {
+            return Err(PaymentError::NotASplitRecipient);
+        }
+        if storage::get_split_withdrawn(&env, &event_id, &recipient) > 0 {
+            return Err(PaymentError::SplitAlreadyWithdrawn);
+        }
+
+        storage::set_split_flagged(&env, &event_id, &recipient, true);
+        events::emit_cohost_flagged(&env, event_id, recipient, primary_organizer);
+        Ok(())
+    }
+
+    /// Resolve a flagged co-host's escrowed share (admin only).
+    ///
+    /// - `ReleaseToRecipient`: clears the flag so the recipient can withdraw.
+    /// - `ReassignToPrimary`: settles the event if needed and transfers the
+    ///   escrowed share to the primary organizer, marking the recipient as paid.
+    pub fn resolve_flagged_share(
+        env: Env,
+        event_id: Symbol,
+        recipient: Address,
+        resolution: FlagResolution,
+    ) -> Result<(), PaymentError> {
+        require_not_paused(&env)?;
+        let admin = storage::get_admin(&env)?;
+        admin.require_auth();
+
+        let splits = storage::get_splits(&env, &event_id);
+        if splits.is_empty() {
+            return Err(PaymentError::SplitsNotConfigured);
+        }
+        if find_split_bps(&splits, &recipient).is_none() {
+            return Err(PaymentError::NotASplitRecipient);
+        }
+        if !storage::is_split_flagged(&env, &event_id, &recipient) {
+            return Err(PaymentError::RecipientNotFlagged);
+        }
+
+        match resolution {
+            FlagResolution::ReleaseToRecipient => {
+                storage::set_split_flagged(&env, &event_id, &recipient, false);
+                events::emit_flagged_share_resolved(&env, event_id, recipient, true, 0);
+            }
+            FlagResolution::ReassignToPrimary => {
+                if storage::get_split_withdrawn(&env, &event_id, &recipient) > 0 {
+                    return Err(PaymentError::SplitAlreadyWithdrawn);
+                }
+                let settlement = ensure_split_settled(&env, &event_id)?;
+                let primary = splits
+                    .get(0)
+                    .ok_or(PaymentError::SplitsNotConfigured)?
+                    .recipient;
+                let share = recipient_share(&splits, &recipient, settlement.net_distributable);
+                if share <= 0 {
+                    return Err(PaymentError::NoRevenue);
+                }
+
+                let token_client = token::Client::new(&env, &settlement.token);
+                token_client.transfer(&env.current_contract_address(), &primary, &share);
+
+                // Mark the flagged recipient as paid so the funds cannot be
+                // double-spent, and clear the flag.
+                storage::set_split_withdrawn(&env, &event_id, &recipient, share);
+                storage::set_split_flagged(&env, &event_id, &recipient, false);
+
+                let record = WithdrawalRecord {
+                    amount: share,
+                    timestamp: env.ledger().timestamp(),
+                    organizer: primary,
+                };
+                storage::add_withdrawal_record(&env, &event_id, &record);
+
+                events::emit_flagged_share_resolved(&env, event_id, recipient, false, share);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Whether a split recipient is currently flagged (share frozen in escrow).
+    pub fn is_recipient_flagged(env: Env, event_id: Symbol, recipient: Address) -> bool {
+        storage::is_split_flagged(&env, &event_id, &recipient)
+    }
+
+    /// Amount already paid out to a given split recipient for an event.
+    pub fn get_split_withdrawn(env: Env, event_id: Symbol, recipient: Address) -> i128 {
+        storage::get_split_withdrawn(&env, &event_id, &recipient)
+    }
 }
 
 #[cfg(test)]
 mod multi_token_test;
+#[cfg(test)]
+mod revenue_split_test;
 #[cfg(test)]
 mod test;

--- a/contracts/payments/src/lib.rs
+++ b/contracts/payments/src/lib.rs
@@ -288,6 +288,32 @@ fn collect_held_payments_for_token(
     Ok((total, payments))
 }
 
+/// Sum the organizer/co-host withdrawable pool for a cancelled event.
+///
+/// Uses every non-released payment so settlement still works after attendees
+/// claim cancellation refunds and their payments move to `Refunded`.
+fn collect_cancellation_organizer_pool(
+    env: &Env,
+    event_id: &Symbol,
+    token_address: &Address,
+    withdrawable_ratio_bps: u32,
+) -> Result<i128, PaymentError> {
+    let payment_ids = storage::get_event_payments(env, event_id);
+    let mut total = 0i128;
+
+    for index in 0..payment_ids.len() {
+        let payment_id = payment_ids
+            .get(index)
+            .ok_or(PaymentError::PaymentNotFound)?;
+        let payment = storage::get_payment(env, payment_id)?;
+        if payment.token == *token_address && payment.status != PaymentStatus::Released {
+            total += payment.amount * (withdrawable_ratio_bps as i128) / 10_000;
+        }
+    }
+
+    Ok(total)
+}
+
 /// Reject legacy single-organizer withdrawal paths for events that carry a
 /// revenue split. Split events must settle through `withdraw_split` so that the
 /// platform fee is deducted once and each recipient is paid exactly their share.
@@ -381,13 +407,22 @@ fn ensure_split_settled(env: &Env, event_id: &Symbol) -> Result<SplitSettlement,
     validate_revenue_invariant(env, event_id)?;
 
     let payout_token = storage::get_event_payout_token(env, event_id)?;
-    let (total, payments_to_release) =
-        collect_held_payments_for_token(env, event_id, &payout_token)?;
-    if total <= 0 {
-        return Err(PaymentError::NoRevenue);
-    }
-
-    let total_to_withdraw = total * (withdrawable_ratio_bps as i128) / 10_000;
+    let is_cancelled = storage::get_event_status(env, event_id) == Some(EventStatus::Cancelled);
+    let (total_to_withdraw, payments_to_release) = if is_cancelled {
+        let pool = collect_cancellation_organizer_pool(
+            env,
+            event_id,
+            &payout_token,
+            withdrawable_ratio_bps,
+        )?;
+        (pool, soroban_sdk::Vec::new(env))
+    } else {
+        let (total, payments) = collect_held_payments_for_token(env, event_id, &payout_token)?;
+        if total <= 0 {
+            return Err(PaymentError::NoRevenue);
+        }
+        (total * (withdrawable_ratio_bps as i128) / 10_000, payments)
+    };
     if total_to_withdraw <= 0 {
         return Err(PaymentError::NoRevenue);
     }
@@ -412,6 +447,8 @@ fn ensure_split_settled(env: &Env, event_id: &Symbol) -> Result<SplitSettlement,
             storage::update_payment(env, &payment)?;
         }
         storage::set_event_token_revenue(env, event_id, &payout_token, 0);
+        let current_rev = storage::get_event_revenue(env, event_id);
+        storage::set_event_revenue(env, event_id, current_rev - total_to_withdraw);
     } else {
         let current_token_rev = storage::get_event_token_revenue(env, event_id, &payout_token);
         storage::set_event_token_revenue(
@@ -1759,6 +1796,13 @@ impl PaymentsContract {
             return Err(PaymentError::InvalidSplitConfig);
         }
 
+        let config =
+            storage::get_event_config(&env, &event_id).ok_or(PaymentError::InvalidOrganizer)?;
+        let (primary, _) = splits.get(0).ok_or(PaymentError::InvalidSplitConfig)?;
+        if primary != config.organizer {
+            return Err(PaymentError::InvalidSplitConfig);
+        }
+
         let mut normalized: soroban_sdk::Vec<RevenueSplit> = soroban_sdk::Vec::new(&env);
         let mut total: u32 = 0;
         for i in 0..len {
@@ -1972,7 +2016,6 @@ impl PaymentsContract {
         storage::is_split_flagged(&env, &event_id, &recipient)
     }
 
-
     /// Amount already paid out to a given split recipient for an event.
     pub fn get_split_withdrawn(env: Env, event_id: Symbol, recipient: Address) -> i128 {
         storage::get_split_withdrawn(&env, &event_id, &recipient)
@@ -2052,8 +2095,8 @@ impl PaymentsContract {
 #[cfg(test)]
 mod multi_token_test;
 #[cfg(test)]
-mod revenue_split_test;
-#[cfg(test)]
 mod receipt_commitment_test;
+#[cfg(test)]
+mod revenue_split_test;
 #[cfg(test)]
 mod test;

--- a/contracts/payments/src/revenue_split_test.rs
+++ b/contracts/payments/src/revenue_split_test.rs
@@ -565,3 +565,48 @@ fn test_cancelled_split_event_distributes_only_withdrawable_ratio() {
     // Remaining 100M stays escrowed for attendee refunds.
     assert_eq!(tc.balance(&contract_id), 100_000_000);
 }
+
+#[test]
+fn test_cancelled_split_settlement_survives_attendee_refund() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, token, client, contract_id, event_contract) = make_payments(&env, 0);
+    let organizer = Address::generate(&env);
+    let cohost = Address::generate(&env);
+    let event_id = symbol_short!("REFND");
+    bind(&client, &event_contract, &event_id, &organizer, &token);
+    let splits: Vec<(Address, u32)> = vec![
+        &env,
+        (organizer.clone(), 6000u32),
+        (cohost.clone(), 4000u32),
+    ];
+    client.sync_revenue_splits(&event_contract, &event_id, &splits);
+
+    let payer = Address::generate(&env);
+    token::StellarAssetClient::new(&env, &token).mint(&payer, &200_000_000);
+    let payment_id = client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &200_000_000,
+        &None,
+        &token,
+        &PaymentPrivacy::Standard,
+    );
+
+    env.ledger().with_mut(|li| li.sequence_number = 500);
+    client.cancel_event(&event_id, &organizer);
+
+    // Attendee claims their 50% refund before organizers withdraw splits.
+    client.claim_refund(&payer, &payment_id);
+
+    env.ledger().with_mut(|li| li.sequence_number = 700);
+
+    let tc = token::Client::new(&env, &token);
+    client.withdraw_split(&cohost, &event_id);
+    client.withdraw_split(&organizer, &event_id);
+
+    assert_eq!(tc.balance(&cohost), 40_000_000);
+    assert_eq!(tc.balance(&organizer), 60_000_000);
+    assert_eq!(tc.balance(&contract_id), 0);
+}

--- a/contracts/payments/src/revenue_split_test.rs
+++ b/contracts/payments/src/revenue_split_test.rs
@@ -1,0 +1,567 @@
+//! Tests for multi-organizer revenue splits and co-host wallet management (#122).
+//!
+//! These exercise the payments-contract surface directly, which is where the
+//! escrowed funds live and where each recipient's share is actually paid out.
+
+use super::*;
+use mock_event_contract::MockEventContract;
+use soroban_sdk::testutils::{Address as _, Ledger};
+use soroban_sdk::{symbol_short, token, vec, Address, Env, Symbol, Vec};
+
+/// Standard split-event setup: payments contract + asset, a bound event whose
+/// organizer is the split index-0 recipient, with revenue already paid in.
+struct SplitFixture<'a> {
+    env: &'a Env,
+    admin: Address,
+    token: Address,
+    client: PaymentsContractClient<'a>,
+    contract_id: Address,
+    organizer: Address,
+    event_id: Symbol,
+}
+
+fn make_payments(
+    env: &Env,
+    fee_bps: u32,
+) -> (
+    Address,
+    Address,
+    PaymentsContractClient<'_>,
+    Address,
+    Address,
+) {
+    let contract_id = env.register(PaymentsContract, ());
+    let client = PaymentsContractClient::new(env, &contract_id);
+    let event_contract = env.register(MockEventContract, ());
+
+    let admin = Address::generate(env);
+    let platform_wallet = Address::generate(env);
+    let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+    let token = token_contract.address();
+    client.initialize(&admin, &token, &fee_bps, &platform_wallet, &event_contract);
+    (admin, token, client, contract_id, event_contract)
+}
+
+fn bind(
+    client: &PaymentsContractClient,
+    event_contract: &Address,
+    event_id: &Symbol,
+    organizer: &Address,
+    token: &Address,
+) {
+    // event_start_ledger=0, event_end_ledger=1000, withdrawal_delay_ledgers=17280
+    // => unlock at ledger 18280.
+    client.sync_event_config(
+        event_contract,
+        event_id,
+        organizer,
+        token,
+        &true,
+        &false,
+        &0,
+        &0,
+        &0,
+        &1000,
+        &17280,
+    );
+}
+
+/// Pay `amount` into the event escrow from a freshly funded payer.
+fn pay(fx: &SplitFixture, nonce: u64, amount: i128) {
+    let payer = Address::generate(fx.env);
+    let asset = token::StellarAssetClient::new(fx.env, &fx.token);
+    asset.mint(&payer, &amount);
+    fx.client.pay_for_ticket(
+        &nonce,
+        &payer,
+        &fx.event_id,
+        &amount,
+        &None,
+        &fx.token,
+        &PaymentPrivacy::Standard,
+    );
+}
+
+fn balance(fx: &SplitFixture, who: &Address) -> i128 {
+    token::Client::new(fx.env, &fx.token).balance(who)
+}
+
+/// Build a completed split event with two recipients (primary 60% / co-host 40%)
+/// and `total` revenue already escrowed. Ledger is advanced past the unlock.
+fn completed_two_way(env: &Env, fee_bps: u32, total: i128) -> (SplitFixture<'_>, Address) {
+    let (admin, token, client, contract_id, event_contract) = make_payments(env, fee_bps);
+    let organizer = Address::generate(env);
+    let cohost = Address::generate(env);
+    let event_id = symbol_short!("SPLITEV");
+
+    bind(&client, &event_contract, &event_id, &organizer, &token);
+    let splits: Vec<(Address, u32)> =
+        vec![env, (organizer.clone(), 6000u32), (cohost.clone(), 4000u32)];
+    client.sync_revenue_splits(&event_contract, &event_id, &splits);
+
+    let _ = event_contract;
+    let fx = SplitFixture {
+        env,
+        admin,
+        token,
+        client,
+        contract_id,
+        organizer,
+        event_id,
+    };
+
+    pay(&fx, 1, total);
+    fx.client
+        .set_event_status(&fx.admin, &fx.event_id, &EventStatus::Completed);
+    env.ledger().with_mut(|li| li.sequence_number = 20_000);
+
+    (fx, cohost)
+}
+
+#[test]
+fn test_sync_revenue_splits_stores_and_reads_back() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, token, client, _cid, event_contract) = make_payments(&env, 0);
+    let organizer = Address::generate(&env);
+    let cohost = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    bind(&client, &event_contract, &event_id, &organizer, &token);
+
+    let splits: Vec<(Address, u32)> = vec![
+        &env,
+        (organizer.clone(), 7000u32),
+        (cohost.clone(), 3000u32),
+    ];
+    client.sync_revenue_splits(&event_contract, &event_id, &splits);
+
+    let read = client.get_revenue_splits(&event_id);
+    assert_eq!(read.len(), 2);
+    assert_eq!(read.get(0).unwrap(), (organizer, 7000u32));
+    assert_eq!(read.get(1).unwrap(), (cohost, 3000u32));
+}
+
+#[test]
+fn test_sync_revenue_splits_rejects_bad_sum() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_a, token, client, _c, event_contract) = make_payments(&env, 0);
+    let organizer = Address::generate(&env);
+    let cohost = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    bind(&client, &event_contract, &event_id, &organizer, &token);
+
+    let bad: Vec<(Address, u32)> = vec![&env, (organizer, 6000u32), (cohost, 3000u32)]; // 9000
+    let res = client.try_sync_revenue_splits(&event_contract, &event_id, &bad);
+    assert_eq!(res.err(), Some(Ok(PaymentError::InvalidSplitConfig)));
+}
+
+#[test]
+fn test_sync_revenue_splits_rejects_more_than_five() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_a, token, client, _c, event_contract) = make_payments(&env, 0);
+    let organizer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    bind(&client, &event_contract, &event_id, &organizer, &token);
+
+    // 6 recipients summing to 10000.
+    let six: Vec<(Address, u32)> = vec![
+        &env,
+        (organizer, 5000u32),
+        (Address::generate(&env), 1000u32),
+        (Address::generate(&env), 1000u32),
+        (Address::generate(&env), 1000u32),
+        (Address::generate(&env), 1000u32),
+        (Address::generate(&env), 1000u32),
+    ];
+    let res = client.try_sync_revenue_splits(&event_contract, &event_id, &six);
+    assert_eq!(res.err(), Some(Ok(PaymentError::InvalidSplitConfig)));
+}
+
+#[test]
+fn test_sync_revenue_splits_rejects_duplicate_and_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_a, token, client, _c, event_contract) = make_payments(&env, 0);
+    let organizer = Address::generate(&env);
+    let dup = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    bind(&client, &event_contract, &event_id, &organizer, &token);
+
+    let duplicate: Vec<(Address, u32)> = vec![
+        &env,
+        (organizer.clone(), 5000u32),
+        (dup.clone(), 2500u32),
+        (dup, 2500u32),
+    ];
+    assert_eq!(
+        client
+            .try_sync_revenue_splits(&event_contract, &event_id, &duplicate)
+            .err(),
+        Some(Ok(PaymentError::InvalidSplitConfig))
+    );
+
+    let zero: Vec<(Address, u32)> =
+        vec![&env, (organizer, 10000u32), (Address::generate(&env), 0u32)];
+    assert_eq!(
+        client
+            .try_sync_revenue_splits(&event_contract, &event_id, &zero)
+            .err(),
+        Some(Ok(PaymentError::InvalidSplitConfig))
+    );
+}
+
+#[test]
+fn test_revenue_splits_are_immutable_once_set() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_a, token, client, _c, event_contract) = make_payments(&env, 0);
+    let organizer = Address::generate(&env);
+    let cohost = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    bind(&client, &event_contract, &event_id, &organizer, &token);
+
+    let splits: Vec<(Address, u32)> = vec![
+        &env,
+        (organizer.clone(), 6000u32),
+        (cohost.clone(), 4000u32),
+    ];
+    client.sync_revenue_splits(&event_contract, &event_id, &splits);
+
+    // A second attempt (even with a different valid config) must be rejected.
+    let changed: Vec<(Address, u32)> = vec![&env, (organizer, 8000u32), (cohost, 2000u32)];
+    let res = client.try_sync_revenue_splits(&event_contract, &event_id, &changed);
+    assert_eq!(res.err(), Some(Ok(PaymentError::InvalidSplitConfig)));
+}
+
+#[test]
+fn test_sync_revenue_splits_rejects_foreign_caller() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_a, token, client, _c, event_contract) = make_payments(&env, 0);
+    let organizer = Address::generate(&env);
+    let cohost = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    bind(&client, &event_contract, &event_id, &organizer, &token);
+
+    let not_event_contract = Address::generate(&env);
+    let splits: Vec<(Address, u32)> = vec![&env, (organizer, 6000u32), (cohost, 4000u32)];
+    let res = client.try_sync_revenue_splits(&not_event_contract, &event_id, &splits);
+    assert_eq!(res.err(), Some(Ok(PaymentError::Unauthorized)));
+}
+
+#[test]
+fn test_platform_fee_deducted_before_split_and_independent_withdrawals() {
+    let env = Env::default();
+    env.mock_all_auths();
+    // 2.5% platform fee, 200M revenue, 60/40 split.
+    let (fx, cohost) = completed_two_way(&env, 250, 200_000_000);
+
+    // Co-host withdraws independently first.
+    fx.client.withdraw_split(&cohost, &fx.event_id);
+    // fee = 5_000_000; net = 195_000_000; co-host 40% = 78_000_000.
+    assert_eq!(balance(&fx, &cohost), 78_000_000);
+    // Primary has not withdrawn yet.
+    assert_eq!(balance(&fx, &fx.organizer), 0);
+
+    // Primary withdraws independently.
+    fx.client.withdraw_split(&fx.organizer, &fx.event_id);
+    assert_eq!(balance(&fx, &fx.organizer), 117_000_000); // 60% of net
+
+    // Platform fee (5M) remains in the contract until the admin sweeps it.
+    assert_eq!(balance(&fx, &fx.contract_id), 5_000_000);
+    assert_eq!(fx.client.get_platform_revenue(&fx.event_id), 5_000_000);
+}
+
+#[test]
+fn test_withdraw_split_rejects_double_withdraw_and_non_recipient() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (fx, cohost) = completed_two_way(&env, 0, 100_000_000);
+
+    fx.client.withdraw_split(&cohost, &fx.event_id);
+    assert_eq!(balance(&fx, &cohost), 40_000_000);
+
+    // Second withdrawal by same recipient is rejected.
+    assert_eq!(
+        fx.client.try_withdraw_split(&cohost, &fx.event_id).err(),
+        Some(Ok(PaymentError::SplitAlreadyWithdrawn))
+    );
+
+    // A stranger is not a recipient.
+    let stranger = Address::generate(&env);
+    assert_eq!(
+        fx.client.try_withdraw_split(&stranger, &fx.event_id).err(),
+        Some(Ok(PaymentError::NotASplitRecipient))
+    );
+}
+
+#[test]
+fn test_withdraw_split_respects_withdrawal_delay() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, event_contract) = make_payments(&env, 0);
+    let organizer = Address::generate(&env);
+    let cohost = Address::generate(&env);
+    let event_id = symbol_short!("SPLITEV");
+    bind(&client, &event_contract, &event_id, &organizer, &token);
+    let splits: Vec<(Address, u32)> = vec![
+        &env,
+        (organizer.clone(), 6000u32),
+        (cohost.clone(), 4000u32),
+    ];
+    client.sync_revenue_splits(&event_contract, &event_id, &splits);
+
+    let payer = Address::generate(&env);
+    token::StellarAssetClient::new(&env, &token).mint(&payer, &100_000_000);
+    client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &100_000_000,
+        &None,
+        &token,
+        &PaymentPrivacy::Standard,
+    );
+    client.set_event_status(&admin, &event_id, &EventStatus::Completed);
+
+    // Before the unlock ledger (18280) settlement must fail.
+    env.ledger().with_mut(|li| li.sequence_number = 5000);
+    assert_eq!(
+        client.try_withdraw_split(&cohost, &event_id).err(),
+        Some(Ok(PaymentError::EscrowNotExpired))
+    );
+
+    // After the unlock it succeeds.
+    env.ledger().with_mut(|li| li.sequence_number = 20_000);
+    client.withdraw_split(&cohost, &event_id);
+    assert_eq!(
+        token::Client::new(&env, &token).balance(&cohost),
+        40_000_000
+    );
+}
+
+#[test]
+fn test_rounding_dust_accrues_to_primary_organizer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, contract_id, event_contract) = make_payments(&env, 0);
+    let organizer = Address::generate(&env);
+    let r2 = Address::generate(&env);
+    let r3 = Address::generate(&env);
+    let event_id = symbol_short!("DUST");
+    bind(&client, &event_contract, &event_id, &organizer, &token);
+    // 3334 / 3333 / 3333 over a net of 100 leaves 1 unit of dust.
+    let splits: Vec<(Address, u32)> = vec![
+        &env,
+        (organizer.clone(), 3334u32),
+        (r2.clone(), 3333u32),
+        (r3.clone(), 3333u32),
+    ];
+    client.sync_revenue_splits(&event_contract, &event_id, &splits);
+
+    let payer = Address::generate(&env);
+    token::StellarAssetClient::new(&env, &token).mint(&payer, &100);
+    client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &100,
+        &None,
+        &token,
+        &PaymentPrivacy::Standard,
+    );
+    client.set_event_status(&admin, &event_id, &EventStatus::Completed);
+    env.ledger().with_mut(|li| li.sequence_number = 20_000);
+
+    let tc = token::Client::new(&env, &token);
+    client.withdraw_split(&r2, &event_id);
+    client.withdraw_split(&r3, &event_id);
+    client.withdraw_split(&organizer, &event_id);
+
+    assert_eq!(tc.balance(&r2), 33);
+    assert_eq!(tc.balance(&r3), 33);
+    assert_eq!(tc.balance(&organizer), 34); // 33 + 1 dust
+                                            // Whole net distributed: nothing left (zero fee).
+    assert_eq!(tc.balance(&contract_id), 0);
+}
+
+#[test]
+fn test_only_primary_can_flag_and_cannot_flag_self() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (fx, cohost) = completed_two_way(&env, 0, 100_000_000);
+
+    // A non-primary caller cannot flag.
+    assert_eq!(
+        fx.client
+            .try_flag_cohost(&cohost, &fx.event_id, &cohost)
+            .err(),
+        Some(Ok(PaymentError::Unauthorized))
+    );
+
+    // Primary cannot flag itself.
+    assert_eq!(
+        fx.client
+            .try_flag_cohost(&fx.organizer, &fx.event_id, &fx.organizer)
+            .err(),
+        Some(Ok(PaymentError::Unauthorized))
+    );
+
+    // Primary flags the co-host successfully.
+    fx.client.flag_cohost(&fx.organizer, &fx.event_id, &cohost);
+    assert!(fx.client.is_recipient_flagged(&fx.event_id, &cohost));
+}
+
+#[test]
+fn test_flagged_cohost_share_held_in_escrow() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (fx, cohost) = completed_two_way(&env, 0, 100_000_000);
+
+    fx.client.flag_cohost(&fx.organizer, &fx.event_id, &cohost);
+
+    // Flagged co-host cannot withdraw.
+    assert_eq!(
+        fx.client.try_withdraw_split(&cohost, &fx.event_id).err(),
+        Some(Ok(PaymentError::RecipientFlagged))
+    );
+
+    // Primary can still withdraw its own share independently.
+    fx.client.withdraw_split(&fx.organizer, &fx.event_id);
+    assert_eq!(balance(&fx, &fx.organizer), 60_000_000);
+
+    // The co-host's 40M remains escrowed in the contract.
+    assert_eq!(balance(&fx, &cohost), 0);
+    assert_eq!(balance(&fx, &fx.contract_id), 40_000_000);
+}
+
+#[test]
+fn test_resolve_flag_release_to_recipient_allows_withdrawal() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (fx, cohost) = completed_two_way(&env, 0, 100_000_000);
+
+    fx.client.flag_cohost(&fx.organizer, &fx.event_id, &cohost);
+    fx.client
+        .resolve_flagged_share(&fx.event_id, &cohost, &FlagResolution::ReleaseToRecipient);
+
+    assert!(!fx.client.is_recipient_flagged(&fx.event_id, &cohost));
+    fx.client.withdraw_split(&cohost, &fx.event_id);
+    assert_eq!(balance(&fx, &cohost), 40_000_000);
+}
+
+#[test]
+fn test_resolve_flag_reassign_to_primary_pays_primary_and_blocks_recipient() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (fx, cohost) = completed_two_way(&env, 0, 100_000_000);
+
+    fx.client.flag_cohost(&fx.organizer, &fx.event_id, &cohost);
+    fx.client
+        .resolve_flagged_share(&fx.event_id, &cohost, &FlagResolution::ReassignToPrimary);
+
+    // The escrowed 40M went to the primary organizer.
+    assert_eq!(balance(&fx, &fx.organizer), 40_000_000);
+
+    // The co-host can no longer claim it.
+    assert_eq!(
+        fx.client.try_withdraw_split(&cohost, &fx.event_id).err(),
+        Some(Ok(PaymentError::SplitAlreadyWithdrawn))
+    );
+
+    // Primary still withdraws its own 60M share.
+    fx.client.withdraw_split(&fx.organizer, &fx.event_id);
+    assert_eq!(balance(&fx, &fx.organizer), 100_000_000);
+}
+
+#[test]
+fn test_resolve_requires_flagged_recipient() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (fx, cohost) = completed_two_way(&env, 0, 100_000_000);
+
+    let res = fx.client.try_resolve_flagged_share(
+        &fx.event_id,
+        &cohost,
+        &FlagResolution::ReleaseToRecipient,
+    );
+    assert_eq!(res.err(), Some(Ok(PaymentError::RecipientNotFlagged)));
+}
+
+#[test]
+fn test_legacy_withdraw_paths_rejected_for_split_events() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (fx, _cohost) = completed_two_way(&env, 0, 100_000_000);
+
+    assert_eq!(
+        fx.client.try_withdraw(&fx.organizer, &fx.event_id).err(),
+        Some(Ok(PaymentError::InvalidSplitConfig))
+    );
+    assert_eq!(
+        fx.client
+            .try_withdraw_token(&fx.organizer, &fx.event_id, &fx.token)
+            .err(),
+        Some(Ok(PaymentError::InvalidSplitConfig))
+    );
+    assert_eq!(
+        fx.client
+            .try_withdraw_all_tokens(&fx.organizer, &fx.event_id)
+            .err(),
+        Some(Ok(PaymentError::InvalidSplitConfig))
+    );
+    assert_eq!(
+        fx.client
+            .try_withdraw_revenue(&fx.event_id, &fx.organizer)
+            .err(),
+        Some(Ok(PaymentError::InvalidSplitConfig))
+    );
+}
+
+#[test]
+fn test_cancelled_split_event_distributes_only_withdrawable_ratio() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, token, client, contract_id, event_contract) = make_payments(&env, 0);
+    let organizer = Address::generate(&env);
+    let cohost = Address::generate(&env);
+    let event_id = symbol_short!("CANCEL");
+    bind(&client, &event_contract, &event_id, &organizer, &token);
+    let splits: Vec<(Address, u32)> = vec![
+        &env,
+        (organizer.clone(), 6000u32),
+        (cohost.clone(), 4000u32),
+    ];
+    client.sync_revenue_splits(&event_contract, &event_id, &splits);
+
+    let payer = Address::generate(&env);
+    token::StellarAssetClient::new(&env, &token).mint(&payer, &200_000_000);
+    client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &200_000_000,
+        &None,
+        &token,
+        &PaymentPrivacy::Standard,
+    );
+
+    // Cancel halfway through the event window (start=0, end=1000) => 50% ratio.
+    env.ledger().with_mut(|li| li.sequence_number = 500);
+    client.cancel_event(&event_id, &organizer);
+
+    // Past the dispute window (cancel_ledger 500 + 100).
+    env.ledger().with_mut(|li| li.sequence_number = 700);
+
+    let tc = token::Client::new(&env, &token);
+    client.withdraw_split(&cohost, &event_id);
+    client.withdraw_split(&organizer, &event_id);
+
+    // Only 50% (100M) is distributable: co-host 40M, primary 60M.
+    assert_eq!(tc.balance(&cohost), 40_000_000);
+    assert_eq!(tc.balance(&organizer), 60_000_000);
+    // Remaining 100M stays escrowed for attendee refunds.
+    assert_eq!(tc.balance(&contract_id), 100_000_000);
+}

--- a/contracts/payments/src/storage.rs
+++ b/contracts/payments/src/storage.rs
@@ -711,16 +711,27 @@ pub fn increment_event_sold_count(env: &Env, event_id: &Symbol) -> Result<(), Pa
 
 /// Whether the event has any revenue split configured (more than zero recipients).
 pub fn has_splits(env: &Env, event_id: &Symbol) -> bool {
-    env.storage()
-        .persistent()
-        .has(&DataKey::EventSplits(event_id.clone()))
+    let key = DataKey::EventSplits(event_id.clone());
+    let exists = env.storage().persistent().has(&key);
+    if exists {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, TTL_THRESHOLD, TTL_BUMP);
+    }
+    exists
 }
 
 pub fn get_splits(env: &Env, event_id: &Symbol) -> Vec<RevenueSplit> {
-    env.storage()
-        .persistent()
-        .get(&DataKey::EventSplits(event_id.clone()))
-        .unwrap_or_else(|| Vec::new(env))
+    let key = DataKey::EventSplits(event_id.clone());
+    match env.storage().persistent().get(&key) {
+        Some(splits) => {
+            env.storage()
+                .persistent()
+                .extend_ttl(&key, TTL_THRESHOLD, TTL_BUMP);
+            splits
+        }
+        None => Vec::new(env),
+    }
 }
 
 pub fn set_splits(env: &Env, event_id: &Symbol, splits: &Vec<RevenueSplit>) {
@@ -732,9 +743,16 @@ pub fn set_splits(env: &Env, event_id: &Symbol, splits: &Vec<RevenueSplit>) {
 }
 
 pub fn get_split_settlement(env: &Env, event_id: &Symbol) -> Option<SplitSettlement> {
-    env.storage()
-        .persistent()
-        .get(&DataKey::SplitSettlement(event_id.clone()))
+    let key = DataKey::SplitSettlement(event_id.clone());
+    match env.storage().persistent().get(&key) {
+        Some(settlement) => {
+            env.storage()
+                .persistent()
+                .extend_ttl(&key, TTL_THRESHOLD, TTL_BUMP);
+            Some(settlement)
+        }
+        None => None,
+    }
 }
 
 pub fn set_split_settlement(env: &Env, event_id: &Symbol, settlement: &SplitSettlement) {
@@ -746,13 +764,16 @@ pub fn set_split_settlement(env: &Env, event_id: &Symbol, settlement: &SplitSett
 }
 
 pub fn get_split_withdrawn(env: &Env, event_id: &Symbol, recipient: &Address) -> i128 {
-    env.storage()
-        .persistent()
-        .get(&DataKey::SplitWithdrawn(
-            event_id.clone(),
-            recipient.clone(),
-        ))
-        .unwrap_or(0)
+    let key = DataKey::SplitWithdrawn(event_id.clone(), recipient.clone());
+    match env.storage().persistent().get(&key) {
+        Some(amount) => {
+            env.storage()
+                .persistent()
+                .extend_ttl(&key, TTL_THRESHOLD, TTL_BUMP);
+            amount
+        }
+        None => 0,
+    }
 }
 
 pub fn set_split_withdrawn(env: &Env, event_id: &Symbol, recipient: &Address, amount: i128) {
@@ -764,10 +785,16 @@ pub fn set_split_withdrawn(env: &Env, event_id: &Symbol, recipient: &Address, am
 }
 
 pub fn is_split_flagged(env: &Env, event_id: &Symbol, recipient: &Address) -> bool {
-    env.storage()
-        .persistent()
-        .get(&DataKey::SplitFlagged(event_id.clone(), recipient.clone()))
-        .unwrap_or(false)
+    let key = DataKey::SplitFlagged(event_id.clone(), recipient.clone());
+    match env.storage().persistent().get(&key) {
+        Some(flagged) => {
+            env.storage()
+                .persistent()
+                .extend_ttl(&key, TTL_THRESHOLD, TTL_BUMP);
+            flagged
+        }
+        None => false,
+    }
 }
 
 pub fn set_split_flagged(env: &Env, event_id: &Symbol, recipient: &Address, flagged: bool) {

--- a/contracts/payments/src/storage.rs
+++ b/contracts/payments/src/storage.rs
@@ -1,5 +1,7 @@
 use crate::errors::PaymentError;
-use crate::types::{EscrowMetadata, EventStatus, PaymentRecord, PrivacyLevel, Ticket};
+use crate::types::{
+    EscrowMetadata, EventStatus, PaymentRecord, PrivacyLevel, RevenueSplit, SplitSettlement, Ticket,
+};
 use soroban_sdk::{contracttype, Address, Env, Symbol, Vec};
 
 const TTL_THRESHOLD: u32 = 60 * 60 * 24 * 30;
@@ -60,6 +62,14 @@ pub enum DataKey {
     ContractVersion,
     UserEventTickets(Symbol, Address),
     Paused,
+    /// Configured revenue split recipients for an event (immutable once set).
+    EventSplits(Symbol),
+    /// Frozen net-distributable snapshot taken at first split settlement.
+    SplitSettlement(Symbol),
+    /// Amount already paid out to a given split recipient for an event.
+    SplitWithdrawn(Symbol, Address),
+    /// Whether a split recipient's share is frozen pending dispute resolution.
+    SplitFlagged(Symbol, Address),
 }
 
 pub fn set_event_status(env: &Env, event_id: &Symbol, status: &EventStatus) {
@@ -661,4 +671,75 @@ pub fn increment_event_sold_count(env: &Env, event_id: &Symbol) -> Result<(), Pa
         .ok_or(PaymentError::EventSoldOut)?;
     set_event_config(env, event_id, &config);
     Ok(())
+}
+
+// ── Revenue split helpers ─────────────────────────────────────────────────────
+
+/// Whether the event has any revenue split configured (more than zero recipients).
+pub fn has_splits(env: &Env, event_id: &Symbol) -> bool {
+    env.storage()
+        .persistent()
+        .has(&DataKey::EventSplits(event_id.clone()))
+}
+
+pub fn get_splits(env: &Env, event_id: &Symbol) -> Vec<RevenueSplit> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::EventSplits(event_id.clone()))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+pub fn set_splits(env: &Env, event_id: &Symbol, splits: &Vec<RevenueSplit>) {
+    let key = DataKey::EventSplits(event_id.clone());
+    env.storage().persistent().set(&key, splits);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, TTL_THRESHOLD, TTL_BUMP);
+}
+
+pub fn get_split_settlement(env: &Env, event_id: &Symbol) -> Option<SplitSettlement> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::SplitSettlement(event_id.clone()))
+}
+
+pub fn set_split_settlement(env: &Env, event_id: &Symbol, settlement: &SplitSettlement) {
+    let key = DataKey::SplitSettlement(event_id.clone());
+    env.storage().persistent().set(&key, settlement);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, TTL_THRESHOLD, TTL_BUMP);
+}
+
+pub fn get_split_withdrawn(env: &Env, event_id: &Symbol, recipient: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::SplitWithdrawn(
+            event_id.clone(),
+            recipient.clone(),
+        ))
+        .unwrap_or(0)
+}
+
+pub fn set_split_withdrawn(env: &Env, event_id: &Symbol, recipient: &Address, amount: i128) {
+    let key = DataKey::SplitWithdrawn(event_id.clone(), recipient.clone());
+    env.storage().persistent().set(&key, &amount);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, TTL_THRESHOLD, TTL_BUMP);
+}
+
+pub fn is_split_flagged(env: &Env, event_id: &Symbol, recipient: &Address) -> bool {
+    env.storage()
+        .persistent()
+        .get(&DataKey::SplitFlagged(event_id.clone(), recipient.clone()))
+        .unwrap_or(false)
+}
+
+pub fn set_split_flagged(env: &Env, event_id: &Symbol, recipient: &Address, flagged: bool) {
+    let key = DataKey::SplitFlagged(event_id.clone(), recipient.clone());
+    env.storage().persistent().set(&key, &flagged);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, TTL_THRESHOLD, TTL_BUMP);
 }

--- a/contracts/payments/src/types.rs
+++ b/contracts/payments/src/types.rs
@@ -63,3 +63,38 @@ pub struct WithdrawalRecord {
     pub timestamp: u64,
     pub organizer: Address,
 }
+
+/// A single revenue-split recipient and its allocation in basis points.
+///
+/// The public configuration is expressed as `Vec<(Address, u32)>` (per the
+/// feature spec), but it is normalised into this struct for storage and event
+/// emission so the fields are self-describing.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RevenueSplit {
+    pub recipient: Address,
+    pub basis_points: u32,
+}
+
+/// Snapshot taken the first time any recipient settles a split event.
+///
+/// `net_distributable` is the amount left for the recipients *after* the
+/// platform fee has been deducted and the (cancellation) withdrawable ratio has
+/// been applied. It is frozen so every recipient's share is computed against the
+/// same base regardless of the order in which they withdraw.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SplitSettlement {
+    pub token: Address,
+    pub net_distributable: i128,
+}
+
+/// How a primary organizer's dispute over a flagged co-host wallet is resolved.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum FlagResolution {
+    /// Clear the flag and let the recipient withdraw its share normally.
+    ReleaseToRecipient = 0,
+    /// Send the escrowed share to the primary organizer instead.
+    ReassignToPrimary = 1,
+}


### PR DESCRIPTION
## Linked issue
Closes #122

## What this PR does

Events are no longer locked to a single organizer wallet. An event can now be created with a revenue split — up to five recipients, each with a basis-point allocation summing to 10000. After the platform fee is deducted, each recipient withdraws their own share independently from the payments contract; no single party can drain the others' funds. The primary organizer (split index 0) keeps full admin rights and can flag a compromised co-host wallet, which freezes that recipient's share in escrow until an admin resolves the dispute by either releasing it to the recipient or reassigning it to the primary organizer.

## Change type
- [x] New contract entrypoint
- [x] Struct / storage change
- [x] Event / emission change
- [x] Cross-contract interface change

## Storage impact

| Field | Before | After | Notes |
|-------|--------|-------|-------|
| `CreateEventParams.revenue_splits` / `Event.revenue_splits` | N/A | `Vec<(Address, u32)>` | Empty = legacy single-organizer payout |
| `DataKey::EventSplits(Symbol)` (payments) | N/A | `Vec<RevenueSplit>` | Immutable once set |
| `DataKey::SplitSettlement(Symbol)` (payments) | N/A | `SplitSettlement` | Net-distributable snapshot, frozen at first withdrawal |
| `DataKey::SplitWithdrawn(Symbol, Address)` (payments) | N/A | `i128` | Per-recipient payout tracking |
| `DataKey::SplitFlagged(Symbol, Address)` (payments) | N/A | `bool` | Escrow freeze for flagged co-hosts |

**Is this a breaking storage change?**
- [x] No — additive only. Existing events have no split configured and keep the exact legacy withdrawal behaviour. The new `revenue_splits` field is set on every new `CreateEventParams` (empty `Vec` for the single-organizer case).

## On-chain vs. off-chain behaviour

| Claim | Storage level | Event level | Notes |
|-------|:---:|:---:|------|
| Platform fee deducted before splits | ✅ | ✅ | Fee accumulated to platform revenue in `ensure_split_settled`; `PlatformFeeCollected` emitted once |
| Each recipient paid exactly their share | ✅ | ✅ | `SplitWithdrawn` guards double-withdrawal; `RevenueWithdrawn` emitted per recipient |
| Flagged share held in escrow | ✅ | ✅ | Funds stay in the contract; `CohostFlagged` / `FlaggedShareResolved` emitted |
| Splits immutable after creation | ✅ | n/a | `sync_revenue_splits` rejects any re-set; no setter exists |

## Cross-contract impact
- [x] Yes — added `PaymentsContract::sync_revenue_splits(event_contract, event_id, splits)`, called by the event contract during `create_event`.
  - Callers updated: `event-contract` (`create_event` now syncs the split; `withdraw_split` and `flag_cohost` proxy to payments).
  - No existing signature changed; this is purely additive.

## Security checklist
- [x] New entrypoints are auth-gated: `sync_revenue_splits` requires the linked event contract; `withdraw_split` requires the recipient; `flag_cohost` requires the primary organizer; `resolve_flagged_share` requires the payments admin.
- [x] Withdrawals honour state transitions: completed events respect `event_end_ledger + withdrawal_delay + admin_extension`; cancelled events respect the dispute window and the time-based withdrawable ratio (mirrors `withdraw`).
- [x] Legacy `withdraw` / `withdraw_token` / `withdraw_all_tokens` / `withdraw_revenue` / `release_if_expired` are rejected for split events, preventing double payout.
- [x] Integer division dust is intentionally routed to the primary organizer so the full net is always distributed and never stranded.

## Test coverage

**New tests added (payments — `revenue_split_test.rs`):**
| Test name | What it proves |
|-----------|----------------|
| `test_sync_revenue_splits_stores_and_reads_back` | Config persists and reads back as `(Address, u32)` |
| `test_sync_revenue_splits_rejects_bad_sum` / `_more_than_five` / `_duplicate_and_zero` | Validation of sum=10000, max 5, no dupes/zeros |
| `test_revenue_splits_are_immutable_once_set` | Re-set is rejected |
| `test_sync_revenue_splits_rejects_foreign_caller` | Only the event contract can configure |
| `test_platform_fee_deducted_before_split_and_independent_withdrawals` | Fee first, then independent shares |
| `test_withdraw_split_rejects_double_withdraw_and_non_recipient` | No double payout; strangers rejected |
| `test_withdraw_split_respects_withdrawal_delay` | Escrow delay enforced |
| `test_rounding_dust_accrues_to_primary_organizer` | Dust → primary; full net distributed |
| `test_only_primary_can_flag_and_cannot_flag_self` | Flag authorization |
| `test_flagged_cohost_share_held_in_escrow` | Flagged share frozen; others unaffected |
| `test_resolve_flag_release_to_recipient_allows_withdrawal` | Dispute release path |
| `test_resolve_flag_reassign_to_primary_pays_primary_and_blocks_recipient` | Dispute reassign path |
| `test_resolve_requires_flagged_recipient` | Resolve only on flagged |
| `test_legacy_withdraw_paths_rejected_for_split_events` | Legacy paths blocked |
| `test_cancelled_split_event_distributes_only_withdrawable_ratio` | Cancellation ratio + refund remainder |

**New tests added (event — `integration_tests.rs`):** `test_event_split_end_to_end_distribution`, `test_event_rejects_invalid_split_configurations`, `test_event_flag_cohost_through_front_door`.

**Test count:** 20 new, 18 updated (existing `CreateEventParams` literals), 180 total passing (event 77, payments 103). `cargo fmt --check` and `cargo clippy -D warnings` clean; `cargo build --release` succeeds.

## Acceptance criteria sign-off
- [x] **AC:** Event creation accepts `revenue_splits: Vec<(Address, u32)>` summing to 10000 — `validate_revenue_splits` in `event/lib.rs`; `test_event_split_end_to_end_distribution`.
- [x] **AC:** Maximum 5 split recipients — rejected in both contracts; `test_sync_revenue_splits_rejects_more_than_five`.
- [x] **AC:** Each recipient can independently withdraw — `withdraw_split`; `test_platform_fee_deducted_before_split_and_independent_withdrawals`.
- [x] **AC:** Primary organizer (index 0) retains admin rights — index 0 must equal the organizer; `flag_cohost` is primary-only; event admin ops keyed off `event.organizer`.
- [x] **AC:** Splits immutable after publish — set only at creation, `sync_revenue_splits` rejects re-set; `test_revenue_splits_are_immutable_once_set`.
- [x] **AC:** Platform fee deducted first — `ensure_split_settled` deducts fee before computing shares; asserted in the fee test.
- [x] **AC:** Compromised co-host can be flagged; flagged share escrowed pending dispute — `flag_cohost` + `resolve_flagged_share`; flagging/escrow/resolution tests.

## What this PR deliberately does NOT cover
- Event-status completion is not auto-synced from the event contract to payments (a pre-existing gap); operators still set the payments-side status. Split settlement reuses the same status/timing rules as the existing `withdraw`.
- Mutable/renegotiable splits are intentionally out of scope — splits are immutable by design per the spec.

## Reviewer focus areas
1. `ensure_split_settled` in `payments/lib.rs` — fee-first ordering and the full vs. partial (cancelled) accounting against `validate_revenue_invariant`.
2. `recipient_share` — primary absorbs rounding dust; confirm sum of shares equals net.
3. The `ensure_no_splits` guards on every legacy withdrawal path.

Made with [Cursor](https://cursor.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-recipient revenue split support for events: view configured splits, withdraw allocated shares, and primary-only co-host flagging.
  * Payments now syncs split configuration from the event contract and enables split settlement, split withdrawals, and flagged co-host resolution.
* **Bug Fixes**
  * Improved split validation with explicit rejections for malformed configurations, incorrect basis-point totals, and invalid primary organizer setup.
  * Disabled legacy revenue withdrawal entrypoints for split-configured events.
* **Tests**
  * Added extensive integration/contract tests for end-to-end distribution, invalid splits, access control, co-host flag/resolve flows, and cancelled-event behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->