### PR TITLE
feat(payments): bind zkEmail receipt commitments to payments (#119)

### DIFF
--- a/contracts/payments/src/errors.rs
+++ b/contracts/payments/src/errors.rs
@@ -37,4 +37,10 @@ pub enum PaymentError {
     ContractPaused = 31,
     /// Token transfer failed; no state has been modified
     TransferFailed = 32,
+    /// A zkEmail commitment is already bound to this payment; commitments are
+    /// write-once and cannot be overwritten.
+    CommitmentAlreadySet = 33,
+    /// The payment is in a state that no longer accepts a commitment
+    /// (e.g. it has been refunded).
+    CommitmentNotAllowed = 34,
 }

--- a/contracts/payments/src/events.rs
+++ b/contracts/payments/src/events.rs
@@ -25,6 +25,29 @@ pub struct PaymentReceiptRequested {
     pub requested_at: u64,
 }
 
+/// Emitted when a zkEmail receipt commitment is bound to a payment.
+///
+/// Deliberately carries no email-derivable data: only the payment/event ids and
+/// a timestamp. The commitment hash itself is NOT emitted — it lives only in
+/// contract storage so that an indexer cannot correlate it across payments.
+#[contractevent(data_format = "vec", topics = ["receipt_commitment"])]
+pub struct ReceiptCommitmentBound {
+    pub event_type: Symbol,
+    pub payment_id: u64,
+    pub event_id: Symbol,
+    pub bound_at: u64,
+}
+
+pub fn emit_receipt_commitment_bound(env: &Env, payment_id: u64, event_id: Symbol) {
+    ReceiptCommitmentBound {
+        event_type: event_type(env, "receipt_commitment_bound"),
+        payment_id,
+        event_id,
+        bound_at: env.ledger().timestamp(),
+    }
+    .publish(env);
+}
+
 pub fn emit_payment_receipt_requested(
     env: &Env,
     payment_id: u64,

--- a/contracts/payments/src/lib.rs
+++ b/contracts/payments/src/lib.rs
@@ -1,4 +1,6 @@
 #![no_std]
+#[cfg(test)]
+extern crate std;
 use soroban_sdk::{contract, contractimpl, token, Address, BytesN, Env, Symbol};
 
 mod errors;
@@ -28,6 +30,7 @@ struct PaymentParams {
     is_verified: bool,
     privacy_level: PaymentPrivacy,
     email_hash: Option<BytesN<32>>,
+    zk_email_commitment: Option<BytesN<32>>,
 }
 
 #[contract]
@@ -197,6 +200,9 @@ fn create_payment(env: Env, params: PaymentParams) -> Result<u64, PaymentError> 
         paid_at,
         privacy_level: params.privacy_level.clone(),
         refunded_amount: 0,
+        // Stored, never emitted. Binds the payment to an off-chain email target
+        // without revealing the address.
+        zk_email_commitment: params.zk_email_commitment.clone(),
     };
 
     storage::save_payment(&env, &payment)?;
@@ -393,6 +399,43 @@ impl PaymentsContract {
                 is_verified: false,
                 privacy_level,
                 email_hash,
+                zk_email_commitment: None,
+            },
+        )
+    }
+
+    /// Pay for a ticket and bind a zkEmail receipt commitment in the same call.
+    ///
+    /// `zk_email_commitment` is an optional salted hash of the buyer's email
+    /// (e.g. `H(email || ticket_id)`) computed off-chain. It is stored on the
+    /// payment record and never emitted; the raw email never touches the chain.
+    /// Pass `None` to behave exactly like [`PaymentsContract::pay_for_ticket`]
+    /// (fully anonymous attendees).
+    #[allow(clippy::too_many_arguments)]
+    pub fn pay_for_ticket_with_commitment(
+        env: Env,
+        nonce: u64,
+        payer: Address,
+        event_id: Symbol,
+        amount: i128,
+        email_hash: Option<BytesN<32>>,
+        token_address: Address,
+        privacy_level: PaymentPrivacy,
+        zk_email_commitment: Option<BytesN<32>>,
+    ) -> Result<u64, PaymentError> {
+        create_payment(
+            env,
+            PaymentParams {
+                nonce,
+                payer,
+                event_id,
+                amount,
+                token_address,
+                is_anonymous: false,
+                is_verified: false,
+                privacy_level,
+                email_hash,
+                zk_email_commitment,
             },
         )
     }
@@ -420,6 +463,7 @@ impl PaymentsContract {
                 is_verified,
                 privacy_level: PaymentPrivacy::Standard,
                 email_hash: None,
+                zk_email_commitment: None,
             },
         )
     }
@@ -1365,9 +1409,78 @@ impl PaymentsContract {
 
         Ok(())
     }
+
+    // ── zkEmail receipt commitments ───────────────────────────────────────────
+
+    /// Bind a zkEmail receipt commitment to an existing payment.
+    ///
+    /// This is the canonical path when the commitment is salted with the
+    /// `ticket_id` (which is only known after the payment is created). The payer
+    /// computes `commitment = H(email || ticket_id)` off-chain and binds it here.
+    ///
+    /// Rules:
+    /// - Only the original payer may bind, and must authorize the call.
+    /// - Commitments are write-once: a payment that already has one is rejected.
+    /// - A refunded payment can no longer accept a commitment.
+    /// - Only the salted hash is stored; the raw email never touches the chain
+    ///   and the commitment value is never emitted.
+    pub fn bind_email_commitment(
+        env: Env,
+        payer: Address,
+        payment_id: u64,
+        commitment: BytesN<32>,
+    ) -> Result<(), PaymentError> {
+        require_not_paused(&env)?;
+        payer.require_auth();
+
+        let mut payment = storage::get_payment(&env, payment_id)?;
+        if payment.payer != payer {
+            return Err(PaymentError::Unauthorized);
+        }
+        if payment.status == PaymentStatus::Refunded {
+            return Err(PaymentError::CommitmentNotAllowed);
+        }
+        if payment.zk_email_commitment.is_some() {
+            return Err(PaymentError::CommitmentAlreadySet);
+        }
+
+        payment.zk_email_commitment = Some(commitment);
+        storage::update_payment(&env, &payment)?;
+
+        events::emit_receipt_commitment_bound(&env, payment_id, payment.event_id);
+        Ok(())
+    }
+
+    /// Read the zkEmail commitment stored for a payment, if any.
+    ///
+    /// Returns `None` when the payer opted out. An off-chain relayer reads this
+    /// to learn the commitment, then recomputes `H(email || ticket_id)` from a
+    /// claimed email to confirm delivery eligibility — without the email ever
+    /// being exposed on-chain.
+    pub fn get_payment_commitment(env: Env, payment_id: u64) -> Option<BytesN<32>> {
+        storage::get_payment(&env, payment_id)
+            .ok()
+            .and_then(|p| p.zk_email_commitment)
+    }
+
+    /// Verify a candidate commitment against the one stored for a payment.
+    ///
+    /// Lets a relayer prove delivery eligibility on-chain without revealing the
+    /// email: it supplies a freshly recomputed commitment and gets a boolean.
+    /// Returns `false` if the payment has no stored commitment.
+    pub fn verify_email_commitment(
+        env: Env,
+        payment_id: u64,
+        candidate: BytesN<32>,
+    ) -> Result<bool, PaymentError> {
+        let payment = storage::get_payment(&env, payment_id)?;
+        Ok(payment.zk_email_commitment == Some(candidate))
+    }
 }
 
 #[cfg(test)]
 mod multi_token_test;
+#[cfg(test)]
+mod receipt_commitment_test;
 #[cfg(test)]
 mod test;

--- a/contracts/payments/src/lib.rs
+++ b/contracts/payments/src/lib.rs
@@ -1610,14 +1610,17 @@ impl PaymentsContract {
 
     /// Read the zkEmail commitment stored for a payment, if any.
     ///
-    /// Returns `None` when the payer opted out. An off-chain relayer reads this
-    /// to learn the commitment, then recomputes `H(email || ticket_id)` from a
-    /// claimed email to confirm delivery eligibility — without the email ever
-    /// being exposed on-chain.
-    pub fn get_payment_commitment(env: Env, payment_id: u64) -> Option<BytesN<32>> {
-        storage::get_payment(&env, payment_id)
-            .ok()
-            .and_then(|p| p.zk_email_commitment)
+    /// Returns `Ok(None)` when the payer opted out. Returns
+    /// `Err(PaymentError::PaymentNotFound)` for an invalid `payment_id`. An
+    /// off-chain relayer reads this to learn the commitment, then recomputes
+    /// `H(email || ticket_id)` from a claimed email to confirm delivery
+    /// eligibility — without the email ever being exposed on-chain.
+    pub fn get_payment_commitment(
+        env: Env,
+        payment_id: u64,
+    ) -> Result<Option<BytesN<32>>, PaymentError> {
+        let payment = storage::get_payment(&env, payment_id)?;
+        Ok(payment.zk_email_commitment)
     }
 
     /// Verify a candidate commitment against the one stored for a payment.

--- a/contracts/payments/src/receipt_commitment_test.rs
+++ b/contracts/payments/src/receipt_commitment_test.rs
@@ -1,0 +1,268 @@
+//! Tests for the zkEmail receipt commitment hook (#119).
+//!
+//! The commitment is a salted hash of the buyer's email computed off-chain
+//! (e.g. `H(email || ticket_id)`). These tests assert that the hash is stored
+//! and verifiable, that it is optional, and — critically — that neither the raw
+//! email nor the commitment hash is ever emitted in an event.
+
+use super::*;
+use mock_event_contract::MockEventContract;
+use soroban_sdk::testutils::{Address as _, Events};
+use soroban_sdk::{symbol_short, token, Address, BytesN, Env, Symbol};
+
+struct World<'a> {
+    env: &'a Env,
+    admin: Address,
+    token: Address,
+    client: PaymentsContractClient<'a>,
+}
+
+fn setup(env: &Env, fee_bps: u32) -> World<'_> {
+    let contract_id = env.register(PaymentsContract, ());
+    let client = PaymentsContractClient::new(env, &contract_id);
+    let event_contract = env.register(MockEventContract, ());
+    let admin = Address::generate(env);
+    let platform_wallet = Address::generate(env);
+    let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+    let token = token_contract.address();
+    client.initialize(&admin, &token, &fee_bps, &platform_wallet, &event_contract);
+    World {
+        env,
+        admin,
+        token,
+        client,
+    }
+}
+
+/// Fund a fresh payer and return its address.
+fn funded_payer(w: &World, amount: i128) -> Address {
+    let payer = Address::generate(w.env);
+    token::StellarAssetClient::new(w.env, &w.token).mint(&payer, &amount);
+    payer
+}
+
+fn pay(w: &World, payer: &Address, event_id: &Symbol, amount: i128) -> u64 {
+    w.client.pay_for_ticket(
+        &1,
+        payer,
+        event_id,
+        &amount,
+        &None,
+        &w.token,
+        &PaymentPrivacy::Standard,
+    )
+}
+
+/// Render every emitted event to a debug string. A 32-byte hash, if emitted,
+/// shows up as a contiguous 64-char hex run; absence of that run proves the
+/// hash was never published.
+fn events_debug(env: &Env) -> std::string::String {
+    std::format!("{:?}", env.events().all())
+}
+
+/// The hex run that a `BytesN<32>` filled with `byte` produces in event output.
+fn hash_hex_run(byte: u8) -> std::string::String {
+    std::format!("{:02x}", byte).repeat(32)
+}
+
+#[test]
+fn test_pay_with_commitment_stores_and_reads_back() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let w = setup(&env, 0);
+    let event_id = symbol_short!("EVENT1");
+    let payer = funded_payer(&w, 100_000_000);
+    let commitment = BytesN::from_array(&env, &[7u8; 32]);
+
+    let pid = w.client.pay_for_ticket_with_commitment(
+        &1,
+        &payer,
+        &event_id,
+        &100_000_000,
+        &None,
+        &w.token,
+        &PaymentPrivacy::Standard,
+        &Some(commitment.clone()),
+    );
+
+    // Stored on the record and exposed via the getter.
+    assert_eq!(
+        w.client.get_payment(&pid).zk_email_commitment,
+        Some(commitment.clone())
+    );
+    assert_eq!(w.client.get_payment_commitment(&pid), Some(commitment));
+}
+
+#[test]
+fn test_commitment_is_optional() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let w = setup(&env, 0);
+    let event_id = symbol_short!("EVENT1");
+    let payer = funded_payer(&w, 100_000_000);
+
+    // Fully anonymous attendee: payment proceeds with no commitment.
+    let pid = pay(&w, &payer, &event_id, 100_000_000);
+    assert_eq!(w.client.get_payment_commitment(&pid), None);
+    assert_eq!(w.client.get_payment(&pid).zk_email_commitment, None);
+}
+
+#[test]
+fn test_bind_commitment_after_payment() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let w = setup(&env, 0);
+    let event_id = symbol_short!("EVENT1");
+    let payer = funded_payer(&w, 100_000_000);
+
+    // The realistic flow: pay first (ticket_id assigned), then bind a commitment
+    // salted with that ticket_id.
+    let pid = pay(&w, &payer, &event_id, 100_000_000);
+    assert_eq!(w.client.get_payment_commitment(&pid), None);
+
+    let commitment = BytesN::from_array(&env, &[9u8; 32]);
+    w.client.bind_email_commitment(&payer, &pid, &commitment);
+    assert_eq!(w.client.get_payment_commitment(&pid), Some(commitment));
+}
+
+#[test]
+fn test_bind_commitment_is_write_once() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let w = setup(&env, 0);
+    let event_id = symbol_short!("EVENT1");
+    let payer = funded_payer(&w, 100_000_000);
+    let pid = pay(&w, &payer, &event_id, 100_000_000);
+
+    let first = BytesN::from_array(&env, &[1u8; 32]);
+    w.client.bind_email_commitment(&payer, &pid, &first);
+
+    let second = BytesN::from_array(&env, &[2u8; 32]);
+    let res = w.client.try_bind_email_commitment(&payer, &pid, &second);
+    assert_eq!(res.err(), Some(Ok(PaymentError::CommitmentAlreadySet)));
+    // Original commitment is unchanged.
+    assert_eq!(w.client.get_payment_commitment(&pid), Some(first));
+}
+
+#[test]
+fn test_bind_commitment_requires_payer_ownership() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let w = setup(&env, 0);
+    let event_id = symbol_short!("EVENT1");
+    let payer = funded_payer(&w, 100_000_000);
+    let pid = pay(&w, &payer, &event_id, 100_000_000);
+
+    let attacker = Address::generate(&env);
+    let commitment = BytesN::from_array(&env, &[3u8; 32]);
+    let res = w
+        .client
+        .try_bind_email_commitment(&attacker, &pid, &commitment);
+    assert_eq!(res.err(), Some(Ok(PaymentError::Unauthorized)));
+}
+
+#[test]
+fn test_bind_commitment_rejected_after_refund() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let w = setup(&env, 0);
+    let event_id = symbol_short!("EVENT1");
+    let payer = funded_payer(&w, 100_000_000);
+    let pid = pay(&w, &payer, &event_id, 100_000_000);
+
+    // Admin fully refunds the payment.
+    w.client.refund(&w.admin, &pid, &None);
+
+    let commitment = BytesN::from_array(&env, &[4u8; 32]);
+    let res = w
+        .client
+        .try_bind_email_commitment(&payer, &pid, &commitment);
+    assert_eq!(res.err(), Some(Ok(PaymentError::CommitmentNotAllowed)));
+}
+
+#[test]
+fn test_verify_email_commitment_matches_and_mismatches() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let w = setup(&env, 0);
+    let event_id = symbol_short!("EVENT1");
+    let payer = funded_payer(&w, 100_000_000);
+    let pid = pay(&w, &payer, &event_id, 100_000_000);
+
+    let commitment = BytesN::from_array(&env, &[5u8; 32]);
+    w.client.bind_email_commitment(&payer, &pid, &commitment);
+
+    // A relayer recomputes H(email || ticket_id) and verifies it on-chain.
+    assert!(w.client.verify_email_commitment(&pid, &commitment));
+    let wrong = BytesN::from_array(&env, &[6u8; 32]);
+    assert!(!w.client.verify_email_commitment(&pid, &wrong));
+}
+
+#[test]
+fn test_verify_returns_false_when_no_commitment() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let w = setup(&env, 0);
+    let event_id = symbol_short!("EVENT1");
+    let payer = funded_payer(&w, 100_000_000);
+    let pid = pay(&w, &payer, &event_id, 100_000_000);
+
+    let candidate = BytesN::from_array(&env, &[8u8; 32]);
+    assert!(!w.client.verify_email_commitment(&pid, &candidate));
+}
+
+#[test]
+fn test_commitment_is_stored_but_never_emitted() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let w = setup(&env, 0);
+    let event_id = symbol_short!("EVENT1");
+    let payer = funded_payer(&w, 100_000_000);
+
+    // `email_hash` (a legacy receipt hash) IS emitted in PaymentReceiptRequested;
+    // the new zkEmail `commitment` must NOT be.
+    let receipt_hash = BytesN::from_array(&env, &[0xAAu8; 32]);
+    let commitment = BytesN::from_array(&env, &[0xBBu8; 32]);
+
+    let pid = w.client.pay_for_ticket_with_commitment(
+        &1,
+        &payer,
+        &event_id,
+        &100_000_000,
+        &Some(receipt_hash.clone()),
+        &w.token,
+        &PaymentPrivacy::Standard,
+        &Some(commitment.clone()),
+    );
+
+    let dbg = events_debug(&env);
+    // Positive control: the legacy receipt hash IS emitted, so our detector works.
+    assert!(
+        dbg.contains(&hash_hex_run(0xAA)),
+        "receipt hash should appear in events (positive control)"
+    );
+    // Guarantee: the zkEmail commitment is never emitted in any event.
+    assert!(
+        !dbg.contains(&hash_hex_run(0xBB)),
+        "zkEmail commitment must not appear in any emitted event"
+    );
+    let _ = &receipt_hash;
+    // But it is durably stored and retrievable.
+    assert_eq!(w.client.get_payment_commitment(&pid), Some(commitment));
+}
+
+#[test]
+fn test_bind_event_does_not_leak_commitment() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let w = setup(&env, 0);
+    let event_id = symbol_short!("EVENT1");
+    let payer = funded_payer(&w, 100_000_000);
+    let pid = pay(&w, &payer, &event_id, 100_000_000);
+
+    let commitment = BytesN::from_array(&env, &[0xCDu8; 32]);
+    w.client.bind_email_commitment(&payer, &pid, &commitment);
+
+    // The ReceiptCommitmentBound event carries only ids/timestamp, never the hash.
+    assert!(!events_debug(&env).contains(&hash_hex_run(0xCD)));
+}

--- a/contracts/payments/src/receipt_commitment_test.rs
+++ b/contracts/payments/src/receipt_commitment_test.rs
@@ -252,6 +252,16 @@ fn test_commitment_is_stored_but_never_emitted() {
 }
 
 #[test]
+fn test_get_payment_commitment_not_found() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let w = setup(&env, 0);
+
+    let res = w.client.try_get_payment_commitment(&999);
+    assert_eq!(res.err(), Some(Ok(PaymentError::PaymentNotFound)));
+}
+
+#[test]
 fn test_bind_event_does_not_leak_commitment() {
     let env = Env::default();
     env.mock_all_auths();

--- a/contracts/payments/src/types.rs
+++ b/contracts/payments/src/types.rs
@@ -1,5 +1,5 @@
 pub use privacy_utils::PrivacyLevel;
-use soroban_sdk::{contracttype, Address, Symbol};
+use soroban_sdk::{contracttype, Address, BytesN, Symbol};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -46,6 +46,11 @@ pub struct PaymentRecord {
     pub paid_at: u64,
     pub privacy_level: PaymentPrivacy,
     pub refunded_amount: i128,
+    /// Optional zkEmail receipt commitment binding this payment to an off-chain
+    /// email delivery target. It is a salted hash (e.g. `H(email || ticket_id)`)
+    /// computed off-chain — the raw email is never stored or emitted. `None`
+    /// means the payer opted out (e.g. fully anonymous attendees).
+    pub zk_email_commitment: Option<BytesN<32>>,
 }
 
 #[contracttype]


### PR DESCRIPTION
## Linked issue
Closes #119

---

## What this PR does
The payments contract can now bind an optional zkEmail receipt commitment to each payment record. A buyer (or relayer on their behalf) supplies a salted hash of their email — e.g. `H(email || ticket_id)` — computed entirely off-chain. The hash is stored on the payment record so an off-chain relayer can verify delivery eligibility without ever putting the raw email on-chain. The field is optional: payments without a commitment proceed normally for fully anonymous attendees.

Two integration paths are supported:
1. **At payment time** via the new `pay_for_ticket_with_commitment` entrypoint (when the commitment is already known).
2. **After payment** via `bind_email_commitment` (when the commitment must be salted with `ticket_id`, which is only assigned once the payment is created).

Existing `pay_for_ticket` and `pay_for_ticket_with_options` entrypoints are unchanged and delegate with `None`, so no cross-contract callers break.

---

## Change type
- [x] New contract entrypoint
- [x] Struct / storage change
- [x] Event / emission change
- [ ] Cross-contract interface change
- [ ] Bug fix
- [ ] Refactor / deprecation
- [x] Test-only change
- [ ] Documentation change

---

## Storage impact

| Field | Before | After | Notes |
|-------|--------|-------|-------|
| `PaymentRecord.zk_email_commitment` | N/A | `Option<BytesN<32>>` | Optional salted email hash; `None` = anonymous / opted out |

**Is this a breaking storage change?**
- [x] No — new optional field with a default
- [ ] No — additive only, existing records unaffected
- [ ] Yes — existing stored data must be migrated (attach migration plan below)

---

## On-chain vs. off-chain behaviour

| Claim | Storage level | Event level | Notes / gaps |
|-------|:---:|:---:|------|
| Commitment stored per payment | ✅ | N/A | `PaymentRecord.zk_email_commitment` |
| Raw email never stored | ✅ | ✅ | Only a 32-byte hash is accepted |
| Commitment never emitted | ✅ | ✅ | `ReceiptCommitmentBound` emits only ids + timestamp; positive-control test proves commitment hex never appears in any event |
| Optional — anonymous payments work | ✅ | ✅ | `None` commitment; existing entrypoints unchanged |
| Relayer can verify eligibility | ✅ | N/A | `get_payment_commitment` + `verify_email_commitment` |

---

## Cross-contract impact

- [x] No cross-contract interface was changed
- [ ] Yes — changed: `<!-- fn name -->` in `<!-- contract -->`

Existing cross-contract callers (`event` contract → `pay_for_ticket`) continue to work unchanged because the new field defaults to `None` inside `create_payment`.

---

## Privacy checklist

- [x] Raw wallet addresses are not stored where a commitment or nullifier is appropriate
- [x] Emitted events contain no fields that can be cross-referenced to derive identity
- [ ] The refund / reversal path preserves the privacy level of the original action
- [ ] zkPassport nullifiers (if used) are stored to prevent proof reuse across events
- [x] zkEmail commitments (if used) store only the hash, never the raw address
- [ ] N/A — this PR does not touch any privacy-sensitive flow

Note: the legacy `email_hash` field on `PaymentReceiptRequested` still emits its hash (pre-existing behaviour). The new `zk_email_commitment` is deliberately **not** emitted.

---

## Security checklist

- [x] No new entrypoint is callable without appropriate auth (`require_auth` / admin check)
- [x] Integer arithmetic uses checked ops or Soroban's safe primitives — no silent overflow
- [ ] Any new capacity or supply check cannot be bypassed by batching calls in one tx
- [ ] Escrow / withdrawal logic enforces correct state transitions
- [ ] No free-event attendance path can be drained by a single caller without a commitment scheme
- [ ] N/A — this PR does not touch auth, arithmetic, capacity, or escrow

`bind_email_commitment` requires payer auth, is write-once, and is rejected after refund.

---

## Test coverage

**New tests added:**

| Test name | What it actually proves |
|-----------|------------------------|
| `test_pay_with_commitment_stores_and_reads_back` | Commitment supplied at payment time is persisted and retrievable |
| `test_commitment_is_optional` | Payment proceeds with `None` commitment |
| `test_bind_commitment_after_payment` | Post-payment binding works (ticket_id-salted flow) |
| `test_bind_commitment_is_write_once` | Second bind rejected with `CommitmentAlreadySet` |
| `test_bind_commitment_requires_payer_ownership` | Non-payer cannot bind |
| `test_bind_commitment_rejected_after_refund` | Refunded payment cannot accept commitment |
| `test_verify_email_commitment_matches_and_mismatches` | Relayer verification path works |
| `test_verify_returns_false_when_no_commitment` | Verify returns false when unset |
| `test_commitment_is_stored_but_never_emitted` | Positive control: legacy receipt hash IS emitted; zkEmail commitment is NOT |
| `test_bind_event_does_not_leak_commitment` | `ReceiptCommitmentBound` event carries no hash |

**Edge cases covered:**
- [x] The "happy path" for each new entrypoint
- [x] Rejection of invalid state transitions
- [ ] Boundary values (zero price, max capacity, min/max ledger windows)
- [x] The specific attack or misuse scenario described in the linked issue

**Test count:** 10 new, 96 total in payments-contract; 74 event-contract tests still pass.

---

## Acceptance criteria sign-off

- [x] **AC:** Payments contract optionally stores a `zk_email_commitment: Option<BytesN<32>>` per payment record
  - Satisfied by: `PaymentRecord.zk_email_commitment` in `types.rs`; `test_pay_with_commitment_stores_and_reads_back`
- [x] **AC:** User provides commitment at payment time (hash of email address salted with ticket_id)
  - Satisfied by: `pay_for_ticket_with_commitment` + `bind_email_commitment`; `test_bind_commitment_after_payment`
- [x] **AC:** Commitment is stored — raw email is never stored or emitted in events
  - Satisfied by: only `BytesN<32>` accepted; `test_commitment_is_stored_but_never_emitted`, `test_bind_event_does_not_leak_commitment`
- [x] **AC:** Off-chain relayer can verify commitment to prove delivery eligibility without exposing the email
  - Satisfied by: `get_payment_commitment`, `verify_email_commitment`; `test_verify_email_commitment_matches_and_mismatches`
- [x] **AC:** Commitment field is optional — payment proceeds without it for fully anonymous attendees
  - Satisfied by: existing entrypoints pass `None`; `test_commitment_is_optional`

---

## What this PR deliberately does NOT cover

- Relayer-side email hashing implementation (off-chain; contract accepts the precomputed hash)
- Wiring the event contract to call `pay_for_ticket_with_commitment` (callers can adopt incrementally)
- Migrating or deprecating the legacy `email_hash` / `PaymentReceiptRequested` emission path

---

## Reviewer focus areas

1. Confirm `zk_email_commitment` is never emitted — only stored (see privacy tests with positive control against legacy `email_hash` emission).
2. Review write-once semantics on `bind_email_commitment` (payer auth, refund guard).
3. Confirm existing `pay_for_ticket` callers remain unaffected (additive optional field only).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `cargo fmt` and `cargo clippy`
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Test plan
- [x] `cargo fmt -p payments-contract`
- [x] `cargo clippy -p payments-contract --all-targets -- -D warnings`
- [x] `cargo test -p payments-contract -p event-contract --offline`
- [x] `cargo build -p payments-contract --release --offline`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Payments can now optionally include and store a receipt commitment when a ticket is purchased.
  * Added an entrypoint to bind a commitment after payment, plus APIs to retrieve and verify the stored commitment.
  * Emits a receipt-commitment-bounded event (without exposing commitment contents).
* **Bug Fixes**
  * Commitment binding is restricted to the original payer and is blocked after refunds.
  * Enforces write-once behavior with clearer errors when a commitment is already set or not allowed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->