### PR TITLE
feat(contract): implement immutable payment privacy semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,9 +759,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "event-contract"

--- a/contracts/event/src/errors.rs
+++ b/contracts/event/src/errors.rs
@@ -68,4 +68,9 @@ pub enum EventError {
     /// The submitted `ZkPassportClaim.claim_type` does not match the type
     /// required by the event's `ZkVerificationConfig`.
     ZkClaimTypeMismatch = 41,
+    /// The event is configured for Private/Anonymous payment privacy, which the
+    /// cross-contract `register_for_event` path cannot settle because it has no
+    /// client-generated privacy material (stealth key / nullifier commitment).
+    /// Use the payments contract's privacy-aware entry point directly.
+    PaymentPrivacyUnsupported = 42,
 }

--- a/contracts/event/src/integration_tests.rs
+++ b/contracts/event/src/integration_tests.rs
@@ -117,7 +117,7 @@ fn test_registration_cross_contract_happy_path() {
     assert_eq!(payment_owner_tickets.len(), 1);
     let payment_ticket_id = payment_owner_tickets.get(0).unwrap();
     let payment_ticket = payments_client.get_ticket(&payment_ticket_id);
-    assert_eq!(payment_ticket.owner, attendee);
+    assert_eq!(payment_ticket.owner, Some(attendee.clone()));
     assert_eq!(payment_ticket.event_id, event_id);
 
     let registered = event_client.is_registered(&event_id, &attendee);

--- a/contracts/event/src/lib.rs
+++ b/contracts/event/src/lib.rs
@@ -768,6 +768,10 @@ impl EventContract {
         if event.status != EventStatus::Active {
             return Err(EventError::EventNotActive);
         }
+        // Enforce the event's configured payment privacy before any state is
+        // mutated. This gates both free and paid registrations, so a
+        // Private/Anonymous event never stores a raw attendee via this path.
+        require_settleable_privacy(&env, &event_id)?;
         {
             let mut req_price: Option<i128> = None;
             for t in event.tiers.iter() {
@@ -842,18 +846,6 @@ impl EventContract {
         let ticket_contract = storage::get_ticket_contract(&env)?;
 
         if tier.price > 0 {
-            // Derive and enforce the event's configured payment privacy. This
-            // cross-contract path can only settle Standard payments — Private and
-            // Anonymous require client-generated privacy material (stealth key /
-            // nullifier commitment) that is not available here. Rejecting is
-            // safer than silently storing the raw attendee under Standard.
-            match storage::get_event_privacy(&env, &event_id) {
-                PrivacyLevel::Standard => {}
-                PrivacyLevel::Private | PrivacyLevel::Anonymous => {
-                    return Err(EventError::PaymentPrivacyUnsupported);
-                }
-            }
-
             let payments_client = PaymentsContractClient::new(&env, &payments_contract);
             let token = payments_client.get_accepted_token();
 
@@ -1100,6 +1092,10 @@ impl EventContract {
         if event.status != EventStatus::Active {
             return Err(EventError::EventNotActive);
         }
+        // Same privacy gate as register_for_event: this path settles payments as
+        // Standard, so reject Private/Anonymous events before minting a ticket or
+        // taking payment.
+        require_settleable_privacy(&env, &event_id)?;
         if !event.requires_verification {
             return Err(EventError::ZkVerificationRequired);
         }
@@ -1271,6 +1267,21 @@ impl EventContract {
         payments_client.flag_cohost(&primary_organizer, &event_id, &recipient);
 
         Ok(())
+    }
+}
+
+/// The cross-contract registration paths (`register_for_event`,
+/// `verify_and_attend`) can only settle Standard payments; Private and Anonymous
+/// events require client-generated privacy material (stealth key / nullifier
+/// commitment) that is not available here. Reject those events up front, before
+/// any registration, ticket, or payment state is mutated, rather than silently
+/// storing the raw attendee under Standard.
+fn require_settleable_privacy(env: &Env, event_id: &Symbol) -> Result<(), EventError> {
+    match storage::get_event_privacy(env, event_id) {
+        PrivacyLevel::Standard => Ok(()),
+        PrivacyLevel::Private | PrivacyLevel::Anonymous => {
+            Err(EventError::PaymentPrivacyUnsupported)
+        }
     }
 }
 

--- a/contracts/event/src/lib.rs
+++ b/contracts/event/src/lib.rs
@@ -1147,6 +1147,8 @@ impl EventContract {
                 &None::<BytesN<32>>,
                 &token,
                 &PaymentPrivacy::Standard,
+                &None,
+                &None,
             );
         }
         if has_linked_contracts(&env) {

--- a/contracts/event/src/lib.rs
+++ b/contracts/event/src/lib.rs
@@ -842,6 +842,18 @@ impl EventContract {
         let ticket_contract = storage::get_ticket_contract(&env)?;
 
         if tier.price > 0 {
+            // Derive and enforce the event's configured payment privacy. This
+            // cross-contract path can only settle Standard payments — Private and
+            // Anonymous require client-generated privacy material (stealth key /
+            // nullifier commitment) that is not available here. Rejecting is
+            // safer than silently storing the raw attendee under Standard.
+            match storage::get_event_privacy(&env, &event_id) {
+                PrivacyLevel::Standard => {}
+                PrivacyLevel::Private | PrivacyLevel::Anonymous => {
+                    return Err(EventError::PaymentPrivacyUnsupported);
+                }
+            }
+
             let payments_client = PaymentsContractClient::new(&env, &payments_contract);
             let token = payments_client.get_accepted_token();
 
@@ -853,6 +865,8 @@ impl EventContract {
                 &_email_hash,
                 &token,
                 &PaymentPrivacy::Standard,
+                &None,
+                &None,
             );
         }
 

--- a/contracts/event/src/test.rs
+++ b/contracts/event/src/test.rs
@@ -728,6 +728,33 @@ fn test_register_for_event_happy_path() {
 }
 
 #[test]
+fn test_register_for_event_rejects_non_standard_privacy() {
+    let env = setup_env();
+    let contract_id = env.register(EventContract, ());
+    let client = EventContractClient::new(&env, &contract_id);
+    let organizer = Address::generate(&env);
+    let attendee = Address::generate(&env);
+
+    let (_payments_contract, token, token_admin) =
+        setup_registration_contracts(&env, &client, &organizer);
+    fund_attendee(&env, &token_admin, &token, &attendee, 100_000_000);
+
+    let event_id = setup_event_with_payout_token(&env, &client, &organizer, &token);
+    client.update_event_status(&organizer, &event_id, &EventStatus::Active);
+    // Configure the event for Private payment privacy.
+    client.set_event_privacy(&organizer, &event_id, &PrivacyLevel::Private);
+
+    // The cross-contract registration path cannot settle Private/Anonymous
+    // payments, so it must reject before storing any attendee or ticket state.
+    let result = client.try_register_for_event(&1, &attendee, &event_id, &0, &false, &None);
+    assert_eq!(
+        result.err(),
+        Some(Ok(EventError::PaymentPrivacyUnsupported))
+    );
+    assert!(!client.is_registered(&event_id, &attendee));
+}
+
+#[test]
 fn test_register_for_event_not_active_fails() {
     let env = setup_env();
     let contract_id = env.register(EventContract, ());

--- a/contracts/event/src/test_claims.rs
+++ b/contracts/event/src/test_claims.rs
@@ -185,6 +185,35 @@ fn test_free_ticket_no_limit_succeeds() {
 }
 
 #[test]
+fn test_free_registration_rejected_for_non_standard_privacy() {
+    let env = setup_env();
+    let contract_id = env.register(EventContract, ());
+    let client = EventContractClient::new(&env, &contract_id);
+    let organizer = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_address = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let event_id = Symbol::new(&env, "ev_freepv");
+    let attendee = Address::generate(&env);
+
+    setup_contracts(&env, &client, &organizer, &token_address);
+    // Free (price 0) tier, but the event is configured for Private privacy.
+    create_free_event(&env, &client, &organizer, &token_address, event_id.clone());
+    client.set_event_privacy(&organizer, &event_id, &PrivacyLevel::Private);
+
+    // The free-registration path stores the raw attendee via save_registration
+    // and mint, so a non-Standard event must be rejected before any state is
+    // written — a paid-tier-only gate would let this through.
+    let result = client.try_register_for_event(&1, &attendee, &event_id, &0, &false, &None);
+    assert_eq!(
+        result.err(),
+        Some(Ok(EventError::PaymentPrivacyUnsupported))
+    );
+    assert!(!client.is_registered(&event_id, &attendee));
+}
+
+#[test]
 fn test_free_ticket_claim_limit_exceeded() {
     let env = setup_env();
     let contract_id = env.register(EventContract, ());

--- a/contracts/payments/src/errors.rs
+++ b/contracts/payments/src/errors.rs
@@ -58,4 +58,10 @@ pub enum PaymentError {
     /// The payment is in a state that no longer accepts a commitment
     /// (e.g. it has been refunded).
     CommitmentNotAllowed = 42,
+    /// Anonymous payment is missing its required nullifier commitment
+    MissingNullifierCommitment = 43,
+    /// Private payment is missing its required stealth delivery key
+    MissingStealthDeliveryKey = 44,
+    /// The supplied privacy data does not match the declared privacy level
+    PrivacyLevelMismatch = 45,
 }

--- a/contracts/payments/src/events.rs
+++ b/contracts/payments/src/events.rs
@@ -1,8 +1,56 @@
+use crate::types::{PaymentPrivacy, PaymentRecord, Ticket};
 use privacy_utils::{mask_address, MaskedAddress, PrivacyLevel};
 use soroban_sdk::{contractevent, Address, BytesN, Env, Symbol};
 
 fn event_type(env: &Env, name: &str) -> Symbol {
     Symbol::new(env, name)
+}
+
+/// Map the per-payment `PaymentPrivacy` to the emission `PrivacyLevel` used for masking.
+pub fn payment_privacy_to_level(level: &PaymentPrivacy) -> PrivacyLevel {
+    match level {
+        PaymentPrivacy::Standard => PrivacyLevel::Standard,
+        PaymentPrivacy::Private => PrivacyLevel::Private,
+        PaymentPrivacy::Anonymous => PrivacyLevel::Anonymous,
+    }
+}
+
+/// Derive the masked identity that should appear in an event for a payment,
+/// honouring the per-payment privacy level. No raw address is ever emitted for
+/// Private or Anonymous payments — only the stored hash/commitment is exposed.
+fn masked_payment_identity(env: &Env, payment: &PaymentRecord) -> MaskedAddress {
+    match payment.privacy_level {
+        PaymentPrivacy::Standard => match &payment.payer {
+            Some(addr) => MaskedAddress::Full(addr.clone()),
+            None => MaskedAddress::Hashed(BytesN::from_array(env, &[0u8; 32])),
+        },
+        PaymentPrivacy::Private => match &payment.hashed_wallet {
+            Some(hash) => MaskedAddress::Hashed(hash.clone()),
+            None => MaskedAddress::Hashed(BytesN::from_array(env, &[0u8; 32])),
+        },
+        PaymentPrivacy::Anonymous => match &payment.nullifier_commitment {
+            Some(commitment) => MaskedAddress::Hashed(commitment.clone()),
+            None => MaskedAddress::Hashed(BytesN::from_array(env, &[0u8; 32])),
+        },
+    }
+}
+
+/// Derive the masked identity for a ticket, honouring the per-ticket privacy level.
+fn masked_ticket_identity(env: &Env, ticket: &Ticket) -> MaskedAddress {
+    match ticket.privacy_level {
+        PaymentPrivacy::Standard => match &ticket.owner {
+            Some(addr) => MaskedAddress::Full(addr.clone()),
+            None => MaskedAddress::Hashed(BytesN::from_array(env, &[0u8; 32])),
+        },
+        PaymentPrivacy::Private => match &ticket.hashed_owner {
+            Some(hash) => MaskedAddress::Hashed(hash.clone()),
+            None => MaskedAddress::Hashed(BytesN::from_array(env, &[0u8; 32])),
+        },
+        PaymentPrivacy::Anonymous => match &ticket.nullifier_commitment {
+            Some(commitment) => MaskedAddress::Hashed(commitment.clone()),
+            None => MaskedAddress::Hashed(BytesN::from_array(env, &[0u8; 32])),
+        },
+    }
 }
 
 #[contractevent(data_format = "vec", topics = ["payment"])]
@@ -99,25 +147,18 @@ pub struct EscrowAutoReleased {
     pub released_at: u64,
 }
 
-#[allow(clippy::too_many_arguments)]
-pub fn emit_payment_received(
-    env: &Env,
-    payment_id: u64,
-    event_id: Symbol,
-    payer: Address,
-    amount: i128,
-    token: Address,
-    paid_at: u64,
-    level: &PrivacyLevel,
-) {
+/// Emit a payment-received event using the payment's own privacy level so the
+/// emitted identity (full address / hashed wallet / nullifier commitment)
+/// matches what is stored on-chain for that exact payment.
+pub fn emit_payment_received(env: &Env, payment: &PaymentRecord) {
     PaymentReceived {
         event_type: event_type(env, "payment_received"),
-        payment_id,
-        event_id,
-        payer: mask_address(env, &payer, level.clone()),
-        amount,
-        token,
-        paid_at,
+        payment_id: payment.payment_id,
+        event_id: payment.event_id.clone(),
+        payer: masked_payment_identity(env, payment),
+        amount: payment.amount,
+        token: payment.token.clone(),
+        paid_at: payment.paid_at,
     }
     .publish(env);
 }
@@ -143,41 +184,31 @@ pub fn emit_revenue_withdrawn(
     .publish(env);
 }
 
-pub fn emit_payment_refunded(
-    env: &Env,
-    payment_id: u64,
-    event_id: Symbol,
-    payer: Address,
-    amount: i128,
-    token: Address,
-    level: &PrivacyLevel,
-) {
+/// Emit a refund event preserving the original payment's privacy level. The
+/// identity exposed is derived from the stored payment record, so an Anonymous
+/// payment refunds with its commitment and a Private payment with its hash —
+/// never a raw address.
+pub fn emit_payment_refunded(env: &Env, payment: &PaymentRecord, amount: i128) {
     PaymentRefunded {
         event_type: event_type(env, "payment_refunded"),
-        payment_id,
-        event_id,
-        payer: mask_address(env, &payer, level.clone()),
+        payment_id: payment.payment_id,
+        event_id: payment.event_id.clone(),
+        payer: masked_payment_identity(env, payment),
         amount,
-        token,
+        token: payment.token.clone(),
         refunded_at: env.ledger().timestamp(),
     }
     .publish(env);
 }
 
-pub fn emit_ticket_issued(
-    env: &Env,
-    ticket_id: u64,
-    event_id: Symbol,
-    owner: Address,
-    payment_id: u64,
-    level: &PrivacyLevel,
-) {
+/// Emit a ticket-issued event using the ticket's own privacy level.
+pub fn emit_ticket_issued(env: &Env, ticket: &Ticket) {
     TicketIssued {
         event_type: event_type(env, "ticket_issued"),
-        ticket_id,
-        event_id,
-        owner: mask_address(env, &owner, level.clone()),
-        payment_id,
+        ticket_id: ticket.ticket_id,
+        event_id: ticket.event_id.clone(),
+        owner: masked_ticket_identity(env, ticket),
+        payment_id: ticket.payment_id,
         issued_at: env.ledger().timestamp(),
     }
     .publish(env);

--- a/contracts/payments/src/lib.rs
+++ b/contracts/payments/src/lib.rs
@@ -722,6 +722,8 @@ impl PaymentsContract {
         email_hash: Option<BytesN<32>>,
         token_address: Address,
         privacy_level: PaymentPrivacy,
+        nullifier_commitment: Option<BytesN<32>>,
+        stealth_delivery_key: Option<BytesN<32>>,
     ) -> Result<u64, PaymentError> {
         create_payment(
             env,
@@ -736,6 +738,8 @@ impl PaymentsContract {
                 privacy_level,
                 email_hash,
                 zk_email_commitment: None,
+                nullifier_commitment,
+                stealth_delivery_key,
             },
         )
     }
@@ -764,6 +768,8 @@ impl PaymentsContract {
                 privacy_level,
                 email_hash,
                 zk_email_commitment,
+                nullifier_commitment: None,
+                stealth_delivery_key: None,
             },
         )
     }
@@ -792,6 +798,8 @@ impl PaymentsContract {
                 privacy_level: PaymentPrivacy::Standard,
                 email_hash: None,
                 zk_email_commitment: None,
+                nullifier_commitment: None,
+                stealth_delivery_key: None,
             },
         )
     }
@@ -913,6 +921,15 @@ impl PaymentsContract {
 
         let mut payment = storage::get_payment(&env, payment_id)?;
 
+        // Anonymous/Private payments cannot be refunded on-chain (no address stored).
+        // Off-chain settlement via stealth key or nullifier commitment is required.
+        match payment.privacy_level {
+            PaymentPrivacy::Anonymous | PaymentPrivacy::Private => {
+                return Err(PaymentError::RefundNotAllowed);
+            }
+            PaymentPrivacy::Standard => {}
+        }
+
         if payment.status == PaymentStatus::Refunded {
             return Err(PaymentError::PaymentAlreadyRefunded);
         }
@@ -927,8 +944,14 @@ impl PaymentsContract {
             return Err(PaymentError::InvalidAmount);
         }
 
-        let token_client = token::Client::new(&env, &payment.token);
-        token_client.transfer(&env.current_contract_address(), &payment.payer, &refund_amt);
+        // Only Standard payments carry an on-chain payer address to refund to.
+        // Private/Anonymous payments deliberately store no raw address; their
+        // refund settlement is handled off-chain via the stealth delivery key /
+        // nullifier, so no on-chain transfer target is dereferenced here.
+        if let Some(refund_to) = payment.payer.clone() {
+            let token_client = token::Client::new(&env, &payment.token);
+            token_client.transfer(&env.current_contract_address(), &refund_to, &refund_amt);
+        }
 
         payment.refunded_amount += refund_amt;
         if payment.refunded_amount == payment.amount {
@@ -948,15 +971,10 @@ impl PaymentsContract {
             token_revenue - refund_amt,
         );
 
-        events::emit_payment_refunded(
-            &env,
-            payment_id,
-            payment.event_id.clone(),
-            payment.payer,
-            refund_amt,
-            payment.token.clone(),
-            &storage::get_emission_privacy(&env, &payment.event_id),
-        );
+        // Refund event preserves the original payment's privacy level: the
+        // identity exposed is derived from the stored record, never re-derived
+        // from event-level config.
+        events::emit_payment_refunded(&env, &payment, refund_amt);
 
         Ok(())
     }
@@ -1190,7 +1208,15 @@ impl PaymentsContract {
         payer.require_auth();
 
         let mut payment = storage::get_payment(&env, payment_id)?;
-        if payment.payer != payer {
+        // Only Standard payments carry an on-chain payer address and are
+        // refundable through this path. Anonymous/Private payments store no
+        // address, so an on-chain refund is not possible — settlement happens
+        // off-chain via the stealth key / nullifier commitment.
+        let stored_payer = payment
+            .payer
+            .clone()
+            .ok_or(PaymentError::RefundNotAllowed)?;
+        if stored_payer != payer {
             return Err(PaymentError::Unauthorized);
         }
         if payment.status != PaymentStatus::Held {

--- a/contracts/payments/src/lib.rs
+++ b/contracts/payments/src/lib.rs
@@ -1355,7 +1355,11 @@ impl PaymentsContract {
         }
 
         let token_client = token::Client::new(&env, &payment.token);
-        token_client.transfer(&env.current_contract_address(), &payment.payer, &refund_amt);
+        token_client.transfer(
+            &env.current_contract_address(),
+            &refund_recipient,
+            &refund_amt,
+        );
 
         payment.refunded_amount += refund_amt;
         payment.status = PaymentStatus::Refunded;
@@ -1373,15 +1377,9 @@ impl PaymentsContract {
             token_revenue - refund_amt,
         );
 
-        events::emit_payment_refunded(
-            &env,
-            payment.payment_id,
-            payment.event_id.clone(),
-            payment.payer.clone(),
-            refund_amt,
-            payment.token.clone(),
-            &storage::get_emission_privacy(&env, &payment.event_id),
-        );
+        // The refund event derives its masked identity from the stored payment,
+        // preserving the original privacy level.
+        events::emit_payment_refunded(&env, &payment, refund_amt);
 
         Ok(())
     }
@@ -2105,7 +2103,9 @@ impl PaymentsContract {
         payer.require_auth();
 
         let mut payment = storage::get_payment(&env, payment_id)?;
-        if payment.payer != payer {
+        // Only Standard payments expose a payer address to authorize against;
+        // Anonymous/Private payments have no on-chain payer to bind a commitment.
+        if payment.payer.as_ref() != Some(&payer) {
             return Err(PaymentError::Unauthorized);
         }
         if payment.status == PaymentStatus::Refunded {

--- a/contracts/payments/src/lib.rs
+++ b/contracts/payments/src/lib.rs
@@ -1244,7 +1244,7 @@ impl PaymentsContract {
         }
 
         let token_client = token::Client::new(&env, &payment.token);
-        token_client.transfer(&env.current_contract_address(), &payment.payer, &remaining);
+        token_client.transfer(&env.current_contract_address(), &stored_payer, &remaining);
 
         payment.refunded_amount += remaining;
         payment.status = PaymentStatus::Refunded;
@@ -1262,15 +1262,9 @@ impl PaymentsContract {
             token_revenue - remaining,
         );
 
-        events::emit_payment_refunded(
-            &env,
-            payment_id,
-            payment.event_id.clone(),
-            payment.payer,
-            remaining,
-            payment.token.clone(),
-            &storage::get_emission_privacy(&env, &payment.event_id),
-        );
+        // The refund event derives its masked identity from the stored payment,
+        // preserving the original privacy level.
+        events::emit_payment_refunded(&env, &payment, remaining);
 
         Ok(())
     }
@@ -1327,11 +1321,17 @@ impl PaymentsContract {
         event_contract.require_auth();
 
         let ticket = storage::get_ticket(&env, ticket_id)?;
-        if ticket.owner != caller {
+        // Only Standard tickets are address-owned and refundable on-chain.
+        let ticket_owner = ticket.owner.clone().ok_or(PaymentError::RefundNotAllowed)?;
+        if ticket_owner != caller {
             return Err(PaymentError::Unauthorized);
         }
 
         let mut payment = storage::get_payment(&env, ticket.payment_id)?;
+        let refund_recipient = payment
+            .payer
+            .clone()
+            .ok_or(PaymentError::RefundNotAllowed)?;
         if payment.status == PaymentStatus::Refunded {
             return Err(PaymentError::PaymentAlreadyRefunded);
         }

--- a/contracts/payments/src/lib.rs
+++ b/contracts/payments/src/lib.rs
@@ -343,39 +343,45 @@ fn create_payment(env: Env, params: PaymentParams) -> Result<u64, PaymentError> 
     let payment_id = storage::get_next_payment_id(&env);
     let paid_at = env.ledger().timestamp();
 
-    let payment = PaymentRecord {
-        payment_id,
-        event_id: params.event_id.clone(),
-        payer: params.payer.clone(),
-        amount: params.amount,
-        token: params.token_address.clone(),
-        status: PaymentStatus::Held,
-        paid_at,
-        privacy_level: params.privacy_level.clone(),
-        refunded_amount: 0,
-        zk_email_commitment: params.zk_email_commitment.clone(),
-    };
+    let payment = build_payment_record(&env, &params, payment_id, paid_at)?;
+
+    // Enforce nullifier uniqueness for Anonymous payments so the same commitment
+    // cannot be spent twice.
+    if let Some(commitment) = &payment.nullifier_commitment {
+        if storage::has_nullifier(&env, commitment) {
+            return Err(PaymentError::DuplicateRequest);
+        }
+        storage::mark_nullifier_spent(&env, commitment);
+    }
 
     storage::save_payment(&env, &payment)?;
     storage::add_event_payment(&env, &params.event_id, payment_id);
-    storage::add_payer_payment(&env, &params.payer, payment_id);
-    storage::set_nonce(&env, &params.payer, params.nonce);
+    // Only Standard payments are indexed by raw address. Indexing Private or
+    // Anonymous payments by their wallet would leak the payer identity.
+    if payment.privacy_level == PaymentPrivacy::Standard {
+        storage::add_payer_payment(&env, &params.payer, payment_id);
+    }
+    match params.privacy_level {
+        PaymentPrivacy::Standard => {
+            storage::set_nonce(&env, &params.payer, params.nonce);
+        }
+        PaymentPrivacy::Private => {
+            let payer_hash = private_wallet_hash(&env, &params.payer);
+            storage::set_nonce_hash(&env, &payer_hash, params.nonce);
+        }
+        PaymentPrivacy::Anonymous => {
+            // Key the nonce by the nullifier commitment, never the payer, so no
+            // wallet-linked value is written to a ledger key.
+            if let Some(commitment) = &payment.nullifier_commitment {
+                storage::set_nonce_hash(&env, commitment, params.nonce);
+            }
+        }
+    }
     storage::add_event_revenue(&env, &params.event_id, params.amount);
     storage::add_event_token_revenue(&env, &params.event_id, &params.token_address, params.amount);
     storage::add_event_token(&env, &params.event_id, &params.token_address);
 
-    let privacy = storage::get_emission_privacy(&env, &params.event_id);
-
-    events::emit_payment_received(
-        &env,
-        payment_id,
-        params.event_id.clone(),
-        params.payer.clone(),
-        params.amount,
-        params.token_address.clone(),
-        paid_at,
-        &privacy,
-    );
+    events::emit_payment_received(&env, &payment);
 
     if let Some(hash) = params.email_hash {
         events::emit_payment_receipt_requested(
@@ -387,26 +393,29 @@ fn create_payment(env: Env, params: PaymentParams) -> Result<u64, PaymentError> 
     }
 
     let ticket_id = storage::get_next_ticket_id(&env);
-    let ticket = Ticket {
-        ticket_id,
-        event_id: payment.event_id.clone(),
-        owner: payment.payer.clone(),
-        payment_id,
-    };
+    let ticket = build_ticket(&payment, ticket_id);
     storage::save_ticket(&env, &ticket)?;
-    storage::add_owner_ticket(&env, &payment.payer, ticket_id);
-    storage::increment_user_event_tickets(&env, &params.event_id, &params.payer);
+    // Only Standard tickets are indexed by owner address; indexing the others
+    // would leak the owner identity for Private/Anonymous purchases.
+    if payment.privacy_level == PaymentPrivacy::Standard {
+        storage::add_owner_ticket(&env, &params.payer, ticket_id);
+    }
+    match params.privacy_level {
+        PaymentPrivacy::Standard => {
+            storage::increment_user_event_tickets(&env, &params.event_id, &params.payer);
+        }
+        PaymentPrivacy::Private => {
+            let payer_hash = private_wallet_hash(&env, &params.payer);
+            storage::increment_user_event_tickets_hash(&env, &params.event_id, &payer_hash);
+        }
+        // Anonymous payments are not counted against a per-wallet ticket cap
+        // (see the read path); nothing wallet-derived is persisted.
+        PaymentPrivacy::Anonymous => {}
+    }
     if storage::get_event_config(&env, &params.event_id).is_some() {
         storage::increment_event_sold_count(&env, &params.event_id)?;
     }
-    events::emit_ticket_issued(
-        &env,
-        ticket_id,
-        payment.event_id,
-        payment.payer,
-        payment_id,
-        &privacy,
-    );
+    events::emit_ticket_issued(&env, &ticket);
 
     Ok(payment_id)
 }

--- a/contracts/payments/src/lib.rs
+++ b/contracts/payments/src/lib.rs
@@ -1,7 +1,9 @@
 #![no_std]
 #[cfg(test)]
 extern crate std;
-use soroban_sdk::{contract, contractimpl, token, Address, BytesN, Env, IntoVal, Symbol};
+use soroban_sdk::{
+    contract, contractimpl, token, xdr::ToXdr, Address, Bytes, BytesN, Env, IntoVal, Symbol,
+};
 
 mod errors;
 mod events;
@@ -29,6 +31,124 @@ struct PaymentParams {
     privacy_level: PaymentPrivacy,
     email_hash: Option<BytesN<32>>,
     zk_email_commitment: Option<BytesN<32>>,
+    nullifier_commitment: Option<BytesN<32>>,
+    stealth_delivery_key: Option<BytesN<32>>,
+}
+
+/// Build a privacy-level-aware payment record. Exactly one identity representation
+/// is populated based on the declared privacy level:
+/// - Anonymous: only `nullifier_commitment` (no address, no hash)
+/// - Private:   only `hashed_wallet` + `stealth_delivery_key` (no raw address)
+/// - Standard:  only `payer` address
+///
+/// Privacy material is mutually exclusive: supplying a field that belongs to a
+/// different privacy level is rejected with `PrivacyLevelMismatch`.
+fn build_payment_record(
+    env: &Env,
+    params: &PaymentParams,
+    payment_id: u64,
+    paid_at: u64,
+) -> Result<PaymentRecord, PaymentError> {
+    match params.privacy_level {
+        PaymentPrivacy::Anonymous => {
+            if params.stealth_delivery_key.is_some() {
+                return Err(PaymentError::PrivacyLevelMismatch);
+            }
+            let commitment = params
+                .nullifier_commitment
+                .clone()
+                .ok_or(PaymentError::MissingNullifierCommitment)?;
+            Ok(PaymentRecord {
+                payment_id,
+                event_id: params.event_id.clone(),
+                payer: None,
+                hashed_wallet: None,
+                stealth_delivery_key: None,
+                nullifier_commitment: Some(commitment),
+                amount: params.amount,
+                token: params.token_address.clone(),
+                status: PaymentStatus::Held,
+                paid_at,
+                privacy_level: PaymentPrivacy::Anonymous,
+                refunded_amount: 0,
+                zk_email_commitment: params.zk_email_commitment.clone(),
+            })
+        }
+        PaymentPrivacy::Private => {
+            if params.nullifier_commitment.is_some() {
+                return Err(PaymentError::PrivacyLevelMismatch);
+            }
+            let stealth_key = params
+                .stealth_delivery_key
+                .clone()
+                .ok_or(PaymentError::MissingStealthDeliveryKey)?;
+            // Salt the wallet hash with the stealth key to prevent brute-force
+            // enumeration of the payer address from the stored hash.
+            let mut preimage = params.payer.clone().to_xdr(env);
+            let stealth_array = stealth_key.to_array();
+            let stealth_bytes = Bytes::from_slice(env, stealth_array.as_ref());
+            preimage.append(&stealth_bytes);
+            let hashed: BytesN<32> = env.crypto().sha256(&preimage).into();
+            Ok(PaymentRecord {
+                payment_id,
+                event_id: params.event_id.clone(),
+                payer: None,
+                hashed_wallet: Some(hashed),
+                stealth_delivery_key: Some(stealth_key),
+                nullifier_commitment: None,
+                amount: params.amount,
+                token: params.token_address.clone(),
+                status: PaymentStatus::Held,
+                paid_at,
+                privacy_level: PaymentPrivacy::Private,
+                refunded_amount: 0,
+                zk_email_commitment: params.zk_email_commitment.clone(),
+            })
+        }
+        PaymentPrivacy::Standard => {
+            if params.nullifier_commitment.is_some() || params.stealth_delivery_key.is_some() {
+                return Err(PaymentError::PrivacyLevelMismatch);
+            }
+            Ok(PaymentRecord {
+                payment_id,
+                event_id: params.event_id.clone(),
+                payer: Some(params.payer.clone()),
+                hashed_wallet: None,
+                stealth_delivery_key: None,
+                nullifier_commitment: None,
+                amount: params.amount,
+                token: params.token_address.clone(),
+                status: PaymentStatus::Held,
+                paid_at,
+                privacy_level: PaymentPrivacy::Standard,
+                refunded_amount: 0,
+                zk_email_commitment: params.zk_email_commitment.clone(),
+            })
+        }
+    }
+}
+
+/// Build a privacy-level-aware ticket from a payment record. The ticket exposes
+/// the same identity representation as its payment.
+fn build_ticket(payment: &PaymentRecord, ticket_id: u64) -> Ticket {
+    Ticket {
+        ticket_id,
+        event_id: payment.event_id.clone(),
+        owner: payment.payer.clone(),
+        hashed_owner: payment.hashed_wallet.clone(),
+        nullifier_commitment: payment.nullifier_commitment.clone(),
+        payment_id: payment.payment_id,
+        privacy_level: payment.privacy_level.clone(),
+    }
+}
+
+/// SHA-256 of the payer address, used as the privacy-preserving ledger key for
+/// **Private** payments (nonce replay-protection and per-user ticket counters).
+/// Private payments accept wallet hashing by design; the raw address is never
+/// written to a ledger key.
+fn private_wallet_hash(env: &Env, payer: &Address) -> BytesN<32> {
+    let payer_xdr = payer.clone().to_xdr(env);
+    env.crypto().sha256(&payer_xdr).into()
 }
 
 #[contract]

--- a/contracts/payments/src/lib.rs
+++ b/contracts/payments/src/lib.rs
@@ -2163,7 +2163,9 @@ impl PaymentsContract {
         seller.require_auth();
 
         let ticket = storage::get_ticket(&env, ticket_id)?;
-        if ticket.owner != seller {
+        // Only Standard tickets are address-owned; Anonymous/Private tickets are
+        // not resale-eligible through this address-based path.
+        if ticket.owner.as_ref() != Some(&seller) {
             return Err(PaymentError::Unauthorized);
         }
 
@@ -2219,7 +2221,7 @@ impl PaymentsContract {
             storage::get_resale_listing(&env, ticket_id).ok_or(PaymentError::TicketNotFound)?;
         let ticket = storage::get_ticket(&env, ticket_id)?;
 
-        if listing.seller != ticket.owner {
+        if ticket.owner.as_ref() != Some(&listing.seller) {
             storage::remove_resale_listing(&env, ticket_id);
             return Err(PaymentError::Unauthorized);
         }
@@ -2273,7 +2275,7 @@ impl PaymentsContract {
         );
 
         let mut new_ticket = ticket.clone();
-        new_ticket.owner = buyer.clone();
+        new_ticket.owner = Some(buyer.clone());
         let key = crate::storage::DataKey::Ticket(ticket_id);
         env.storage().persistent().set(&key, &new_ticket);
 
@@ -2299,3 +2301,5 @@ mod receipt_commitment_test;
 mod revenue_split_test;
 #[cfg(test)]
 mod test;
+#[cfg(test)]
+mod test_privacy_semantics;

--- a/contracts/payments/src/lib.rs
+++ b/contracts/payments/src/lib.rs
@@ -253,6 +253,12 @@ fn require_not_paused(env: &Env) -> Result<(), PaymentError> {
 
 #[allow(clippy::too_many_arguments)]
 fn create_payment(env: Env, params: PaymentParams) -> Result<u64, PaymentError> {
+    // Privacy note: `require_auth()` runs for all privacy levels because the payer
+    // must authorize the token transfer. This means the submitting wallet address
+    // is visible in the transaction envelope regardless of the selected privacy level.
+    // Anonymous/Private privacy applies at the contract storage and event layer only
+    // (what the contract records on-chain), not at the transaction-submission layer.
+    // True transaction-level anonymity requires a relayer/meta-transaction model.
     params.payer.require_auth();
     require_not_paused(&env)?;
 
@@ -260,7 +266,23 @@ fn create_payment(env: Env, params: PaymentParams) -> Result<u64, PaymentError> 
         return Err(PaymentError::NonceRequired);
     }
 
-    if storage::has_nonce(&env, &params.payer, params.nonce) {
+    // Nonce uniqueness is tracked by raw address only for Standard payments.
+    // Anonymous/Private payments key the nonce by a hash of the payer so the raw
+    // wallet address is never embedded in a ledger key.
+    let already_used = match params.privacy_level {
+        PaymentPrivacy::Standard => storage::has_nonce(&env, &params.payer, params.nonce),
+        PaymentPrivacy::Private => {
+            let payer_hash = private_wallet_hash(&env, &params.payer);
+            storage::has_nonce_hash(&env, &payer_hash, params.nonce)
+        }
+        // Anonymous replay-protection is keyed by the nullifier commitment, never
+        // the payer, so no wallet-linked value is written to a ledger key.
+        PaymentPrivacy::Anonymous => match &params.nullifier_commitment {
+            Some(commitment) => storage::has_nonce_hash(&env, commitment, params.nonce),
+            None => false,
+        },
+    };
+    if already_used {
         return Err(PaymentError::DuplicateRequest);
     }
 
@@ -281,8 +303,20 @@ fn create_payment(env: Env, params: PaymentParams) -> Result<u64, PaymentError> 
         }
 
         if config.max_tickets_per_user > 0 {
-            let current_tickets =
-                storage::get_user_event_tickets(&env, &params.event_id, &params.payer);
+            let current_tickets = match params.privacy_level {
+                PaymentPrivacy::Standard => {
+                    storage::get_user_event_tickets(&env, &params.event_id, &params.payer)
+                }
+                PaymentPrivacy::Private => {
+                    let payer_hash = private_wallet_hash(&env, &params.payer);
+                    storage::get_user_event_tickets_hash(&env, &params.event_id, &payer_hash)
+                }
+                // Anonymous payments carry a unique nullifier commitment per
+                // purchase, so there is no stable per-wallet identity to enforce a
+                // ticket cap against. Wallet-bound limits do not apply; commitment
+                // uniqueness already prevents reuse.
+                PaymentPrivacy::Anonymous => 0,
+            };
             if current_tickets >= config.max_tickets_per_user {
                 return Err(PaymentError::MaxTicketsReached);
             }

--- a/contracts/payments/src/multi_token_test.rs
+++ b/contracts/payments/src/multi_token_test.rs
@@ -72,6 +72,8 @@ fn test_multi_token_payments() {
         &None,
         &token1,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let payment_id2 = client.pay_for_ticket(
         &1,
@@ -81,6 +83,8 @@ fn test_multi_token_payments() {
         &None,
         &token2,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let payment1 = client.get_payment(&payment_id1);
     let payment2 = client.get_payment(&payment_id2);
@@ -137,6 +141,8 @@ fn test_multi_token_refund_updates_only_the_paid_token_bucket() {
         &None,
         &token1,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     client.pay_for_ticket(
         &2,
@@ -146,6 +152,8 @@ fn test_multi_token_refund_updates_only_the_paid_token_bucket() {
         &None,
         &token2,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     client.refund(&admin, &payment_id1, &None);
@@ -201,6 +209,8 @@ fn test_withdraw_uses_only_the_event_payout_token_revenue() {
         &None,
         &token1,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let second_payment_id = client.pay_for_ticket(
         &2,
@@ -210,6 +220,8 @@ fn test_withdraw_uses_only_the_event_payout_token_revenue() {
         &None,
         &token2,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     client.set_event_status(&admin, &event_id, &EventStatus::Completed);

--- a/contracts/payments/src/receipt_commitment_test.rs
+++ b/contracts/payments/src/receipt_commitment_test.rs
@@ -48,6 +48,8 @@ fn pay(w: &World, payer: &Address, event_id: &Symbol, amount: i128) -> u64 {
         &None,
         &w.token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     )
 }
 fn events_debug(env: &Env) -> std::string::String {

--- a/contracts/payments/src/revenue_split_test.rs
+++ b/contracts/payments/src/revenue_split_test.rs
@@ -82,6 +82,8 @@ fn pay(fx: &SplitFixture, nonce: u64, amount: i128) {
         &None,
         &fx.token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 }
 
@@ -326,6 +328,8 @@ fn test_withdraw_split_respects_withdrawal_delay() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     client.set_event_status(&admin, &event_id, &EventStatus::Completed);
 
@@ -374,6 +378,8 @@ fn test_rounding_dust_accrues_to_primary_organizer() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     client.set_event_status(&admin, &event_id, &EventStatus::Completed);
     env.ledger().with_mut(|li| li.sequence_number = 20_000);
@@ -549,6 +555,8 @@ fn test_cancelled_split_event_distributes_only_withdrawable_ratio() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     // Cancel halfway through the event window (start=0, end=1000) => 50% ratio.
@@ -595,6 +603,8 @@ fn test_cancelled_split_settlement_survives_attendee_refund() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     env.ledger().with_mut(|li| li.sequence_number = 500);

--- a/contracts/payments/src/storage.rs
+++ b/contracts/payments/src/storage.rs
@@ -2,7 +2,7 @@ use crate::errors::PaymentError;
 use crate::types::{
     EscrowMetadata, EventStatus, PaymentRecord, PrivacyLevel, RevenueSplit, SplitSettlement, Ticket,
 };
-use soroban_sdk::{contracttype, Address, Env, Symbol, Vec};
+use soroban_sdk::{contracttype, Address, BytesN, Env, Symbol, Vec};
 
 const TTL_THRESHOLD: u32 = 60 * 60 * 24 * 30;
 const TTL_BUMP: u32 = 60 * 60 * 24 * 30 * 2;
@@ -77,6 +77,13 @@ pub enum DataKey {
     SplitFlagged(Symbol, Address),
     ResaleListing(u64),
     TicketContract,
+    /// Nonce replay-protection keyed by a privacy-preserving wallet hash
+    /// (used for Private payments instead of the raw payer address).
+    ProcessedNonceHash(BytesN<32>, u64),
+    /// Per-user ticket counter keyed by a privacy-preserving wallet hash.
+    UserEventTicketsHash(Symbol, BytesN<32>),
+    /// Records a spent nullifier commitment to guarantee Anonymous-payment uniqueness.
+    SpentNullifier(BytesN<32>),
 }
 
 pub fn set_event_status(env: &Env, event_id: &Symbol, status: &EventStatus) {
@@ -540,6 +547,38 @@ pub fn set_nonce(env: &Env, address: &Address, nonce: u64) {
         .persistent()
         .extend_ttl(&key, 60 * 60 * 24 * 7, 60 * 60 * 24 * 14);
 }
+
+pub fn has_nonce_hash(env: &Env, hash: &BytesN<32>, nonce: u64) -> bool {
+    env.storage()
+        .persistent()
+        .get(&DataKey::ProcessedNonceHash(hash.clone(), nonce))
+        .unwrap_or(false)
+}
+
+pub fn set_nonce_hash(env: &Env, hash: &BytesN<32>, nonce: u64) {
+    let key = DataKey::ProcessedNonceHash(hash.clone(), nonce);
+    env.storage().persistent().set(&key, &true);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, 60 * 60 * 24 * 7, 60 * 60 * 24 * 14);
+}
+
+pub fn has_nullifier(env: &Env, commitment: &BytesN<32>) -> bool {
+    env.storage()
+        .persistent()
+        .get(&DataKey::SpentNullifier(commitment.clone()))
+        .unwrap_or(false)
+}
+
+pub fn mark_nullifier_spent(env: &Env, commitment: &BytesN<32>) {
+    let key = DataKey::SpentNullifier(commitment.clone());
+    env.storage().persistent().set(&key, &true);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, 60 * 60 * 24 * 365, 60 * 60 * 24 * 365 * 2);
+}
+
+/// Get the current contract version from storage.
 pub fn get_contract_version(env: &Env) -> u32 {
     env.storage()
         .persistent()
@@ -632,6 +671,20 @@ pub fn get_user_event_tickets(env: &Env, event_id: &Symbol, user: &Address) -> u
 pub fn increment_user_event_tickets(env: &Env, event_id: &Symbol, user: &Address) {
     let current = get_user_event_tickets(env, event_id, user);
     let key = DataKey::UserEventTickets(event_id.clone(), user.clone());
+    env.storage().persistent().set(&key, &(current + 1));
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, 60 * 60 * 24 * 30, 60 * 60 * 24 * 30 * 2);
+}
+
+pub fn get_user_event_tickets_hash(env: &Env, event_id: &Symbol, user_hash: &BytesN<32>) -> u32 {
+    let key = DataKey::UserEventTicketsHash(event_id.clone(), user_hash.clone());
+    env.storage().persistent().get(&key).unwrap_or(0)
+}
+
+pub fn increment_user_event_tickets_hash(env: &Env, event_id: &Symbol, user_hash: &BytesN<32>) {
+    let current = get_user_event_tickets_hash(env, event_id, user_hash);
+    let key = DataKey::UserEventTicketsHash(event_id.clone(), user_hash.clone());
     env.storage().persistent().set(&key, &(current + 1));
     env.storage()
         .persistent()

--- a/contracts/payments/src/test.rs
+++ b/contracts/payments/src/test.rs
@@ -1551,6 +1551,8 @@ fn test_privacy_levels_stored_correctly() {
         &None,
         &token,
         &PaymentPrivacy::Anonymous,
+        &Some(BytesN::from_array(&env, &[7u8; 32])),
+        &None,
     );
     let pid_priv = client.pay_for_ticket(
         &2,
@@ -1560,6 +1562,8 @@ fn test_privacy_levels_stored_correctly() {
         &None,
         &token,
         &PaymentPrivacy::Private,
+        &None,
+        &Some(BytesN::from_array(&env, &[9u8; 32])),
     );
     let pid_std = client.pay_for_ticket(
         &3,
@@ -1569,6 +1573,8 @@ fn test_privacy_levels_stored_correctly() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     assert_eq!(
@@ -1608,6 +1614,8 @@ fn test_refund_unauthorized() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let result = client.try_refund(&_not_admin, &payment_id, &None);
     assert_eq!(result.err(), Some(Ok(PaymentError::Unauthorized)));
@@ -1679,6 +1687,8 @@ fn test_withdraw_unauthorized_organizer_rejected() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     set_event_status_for_test(&client, &admin, &event_id, &EventStatus::Completed);
 
@@ -1745,6 +1755,8 @@ fn test_double_withdraw_rejected_after_revenue_cleared() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     set_event_status_for_test(&client, &admin, &event_id, &EventStatus::Completed);
     env.ledger().with_mut(|li| {
@@ -1806,6 +1818,8 @@ fn test_withdraw_before_completion_fails() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     env.ledger().with_mut(|li| {
@@ -1838,6 +1852,8 @@ fn test_refund_on_cancelled_event_succeeds() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     set_event_status_for_test(&client, &admin, &event_id, &EventStatus::Cancelled);
@@ -1868,6 +1884,8 @@ fn test_idempotent_payment() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let contract_id = client.address.clone();
     let has_in_storage = env.as_contract(&contract_id, || storage::has_nonce(&env, &payer, nonce));
@@ -1884,6 +1902,8 @@ fn test_idempotent_payment() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     client.pay_for_ticket(
         &nonce,
@@ -1893,6 +1913,8 @@ fn test_idempotent_payment() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 }
 
@@ -1928,6 +1950,8 @@ fn test_pay_for_ticket_transfer_failure_no_state_change() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     assert_eq!(result.err(), Some(Ok(PaymentError::TransferFailed)));
     assert_eq!(
@@ -1960,6 +1984,8 @@ fn test_pay_for_ticket_partial_funds_no_state_change() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     assert_eq!(result.err(), Some(Ok(PaymentError::TransferFailed)));
     assert_eq!(client.get_event_revenue(&event_id), 0);
@@ -2008,6 +2034,8 @@ fn test_max_tickets_per_user_enforcement() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     client.pay_for_ticket(
         &2,
@@ -2017,6 +2045,8 @@ fn test_max_tickets_per_user_enforcement() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let result = client.try_pay_for_ticket(
         &3,
@@ -2026,6 +2056,8 @@ fn test_max_tickets_per_user_enforcement() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     assert_eq!(result.err(), Some(Ok(PaymentError::MaxTicketsReached)));
     client.pay_for_ticket(
@@ -2036,6 +2068,8 @@ fn test_max_tickets_per_user_enforcement() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     assert_eq!(client.get_owner_tickets(&payer1).len(), 2);
@@ -2087,6 +2121,8 @@ fn test_event_supply_enforcement() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     client.pay_for_ticket(
         &1,
@@ -2096,6 +2132,8 @@ fn test_event_supply_enforcement() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     let config = client.get_event_config(&event_id);
@@ -2110,6 +2148,8 @@ fn test_event_supply_enforcement() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     assert_eq!(result.err(), Some(Ok(PaymentError::EventSoldOut)));
     assert_eq!(token_client.balance(&payer3), amount);
@@ -2159,6 +2199,8 @@ fn test_withdraw_revenue_with_fee() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let organizer = Address::generate(&env);
     env.ledger().with_mut(|li| {
@@ -2199,6 +2241,8 @@ fn test_withdraw_revenue_zero_fee() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     let organizer = Address::generate(&env);
@@ -2231,6 +2275,8 @@ fn test_withdraw_platform_revenue() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let organizer = Address::generate(&env);
     env.ledger().with_mut(|li| {
@@ -2307,6 +2353,8 @@ fn test_organizer_withdraw_with_fee() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     set_event_status_for_test(&client, &admin, &event_id, &EventStatus::Completed);
     env.ledger().with_mut(|li| {
@@ -2342,6 +2390,8 @@ fn test_platform_revenue_accumulates_across_withdrawals() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     env.ledger().with_mut(|li| {
         li.sequence_number = 20000;
@@ -2360,6 +2410,8 @@ fn test_platform_revenue_accumulates_across_withdrawals() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     env.ledger().with_mut(|li| {
         li.sequence_number = 20000;
@@ -2393,6 +2445,8 @@ fn test_replay_attack_rejected_detailed() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let result = client.try_pay_for_ticket(
         &nonce,
@@ -2402,6 +2456,8 @@ fn test_replay_attack_rejected_detailed() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     assert_eq!(result.err(), Some(Ok(PaymentError::DuplicateRequest)));
     assert_eq!(client.get_owner_tickets(&payer).len(), 1);
@@ -2434,6 +2490,8 @@ fn test_zero_nonce_rejected() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     assert_eq!(result.err(), Some(Ok(PaymentError::NonceRequired)));
 
@@ -2465,6 +2523,8 @@ fn test_partial_refund_success() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     assert_eq!(client.get_event_revenue(&event_id), amount);
     let partial_1 = 30_000_000i128;
@@ -2518,6 +2578,8 @@ fn test_partial_refund_exceeds_amount_fails() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let result = client.try_refund(&admin, &payment_id, &Some(amount + 1));
     assert!(result.is_err());
@@ -2561,6 +2623,8 @@ fn test_per_user_limit_within_limit_succeeds() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     assert_eq!(client.get_user_tickets(&event_id, &payer), 1);
     client.pay_for_ticket(
@@ -2571,6 +2635,8 @@ fn test_per_user_limit_within_limit_succeeds() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     assert_eq!(client.get_user_tickets(&event_id, &payer), 2);
     assert_eq!(client.get_owner_tickets(&payer).len(), 2);
@@ -2613,6 +2679,8 @@ fn test_per_user_limit_exceed_is_rejected() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let result = client.try_pay_for_ticket(
         &2,
@@ -2622,6 +2690,8 @@ fn test_per_user_limit_exceed_is_rejected() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     assert_eq!(result.err(), Some(Ok(PaymentError::MaxTicketsReached)));
     let result2 = client
@@ -2674,6 +2744,8 @@ fn test_per_user_limit_counters_are_scoped_per_event_and_user() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     client.pay_for_ticket(
         &2,
@@ -2683,6 +2755,8 @@ fn test_per_user_limit_counters_are_scoped_per_event_and_user() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     client.pay_for_ticket(
         &3,
@@ -2692,6 +2766,8 @@ fn test_per_user_limit_counters_are_scoped_per_event_and_user() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     assert_eq!(client.get_user_tickets(&event_x, &payer_a), 1);
     assert_eq!(client.get_user_tickets(&event_x, &payer_b), 1);
@@ -2705,6 +2781,8 @@ fn test_per_user_limit_counters_are_scoped_per_event_and_user() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     assert_eq!(result.err(), Some(Ok(PaymentError::MaxTicketsReached)));
 }
@@ -2735,6 +2813,8 @@ fn test_withdraw_cancelled_event_respects_dispute_window() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     env.ledger().with_mut(|li| {
         li.sequence_number = 1000;
@@ -2781,6 +2861,8 @@ fn test_withdraw_cancelled_event_after_dispute_window_succeeds() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     env.ledger().with_mut(|li| {
         li.sequence_number = 500;

--- a/contracts/payments/src/test.rs
+++ b/contracts/payments/src/test.rs
@@ -116,6 +116,8 @@ fn test_pause_unpause_and_blocks_sensitive_actions() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     assert_eq!(payment_result.err(), Some(Ok(PaymentError::ContractPaused)));
     assert_eq!(token_client.balance(&payer), amount);
@@ -136,6 +138,8 @@ fn test_pause_unpause_and_blocks_sensitive_actions() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     client.set_paused(&admin, &true);
@@ -298,12 +302,14 @@ fn test_pay_for_ticket() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     let payment = client.get_payment(&payment_id);
     assert_eq!(payment.payment_id, payment_id);
     assert_eq!(payment.event_id, event_id);
-    assert_eq!(payment.payer, payer);
+    assert_eq!(payment.payer, Some(payer.clone()));
     assert_eq!(payment.amount, amount);
     assert_eq!(payment.token, token);
     assert_eq!(payment.status, PaymentStatus::Held);
@@ -315,7 +321,7 @@ fn test_pay_for_ticket() {
     let ticket = client.get_ticket(&ticket_id);
     assert_eq!(ticket.ticket_id, ticket_id);
     assert_eq!(ticket.event_id, event_id);
-    assert_eq!(ticket.owner, payer);
+    assert_eq!(ticket.owner, Some(payer.clone()));
     assert_eq!(ticket.payment_id, payment_id);
 
     let contract_balance = token_client.balance(&contract_id);
@@ -350,6 +356,8 @@ fn test_payment_issues_ticket_and_links_payment() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let owner_tickets = client.get_owner_tickets(&payer);
 
@@ -359,7 +367,7 @@ fn test_payment_issues_ticket_and_links_payment() {
     let ticket = client.get_ticket(&ticket_id);
     assert_eq!(ticket.ticket_id, ticket_id);
     assert_eq!(ticket.event_id, event_id);
-    assert_eq!(ticket.owner, payer);
+    assert_eq!(ticket.owner, Some(payer.clone()));
     assert_eq!(ticket.payment_id, payment_id);
 }
 
@@ -386,6 +394,8 @@ fn test_multiple_payments_create_distinct_tickets_for_owner() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let payment_id_2 = client.pay_for_ticket(
         &2,
@@ -395,6 +405,8 @@ fn test_multiple_payments_create_distinct_tickets_for_owner() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     let owner_tickets = client.get_owner_tickets(&payer);
@@ -404,8 +416,8 @@ fn test_multiple_payments_create_distinct_tickets_for_owner() {
     let ticket_2 = client.get_ticket(&owner_tickets.get(1).unwrap());
 
     assert_ne!(ticket_1.ticket_id, ticket_2.ticket_id);
-    assert_eq!(ticket_1.owner, payer);
-    assert_eq!(ticket_2.owner, payer);
+    assert_eq!(ticket_1.owner, Some(payer.clone()));
+    assert_eq!(ticket_2.owner, Some(payer.clone()));
     assert_eq!(ticket_1.payment_id, payment_id_1);
     assert_eq!(ticket_2.payment_id, payment_id_2);
 }
@@ -427,6 +439,8 @@ fn test_pay_for_ticket_invalid_amount_zero() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     assert_eq!(result.err(), Some(Ok(PaymentError::InvalidAmount)));
 }
@@ -448,6 +462,8 @@ fn test_pay_for_ticket_invalid_amount_negative() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     assert_eq!(result.err(), Some(Ok(PaymentError::InvalidAmount)));
 }
@@ -545,6 +561,8 @@ fn test_pay_for_ticket_unauthorized() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 }
 
@@ -575,6 +593,8 @@ fn test_pay_for_ticket_multiple_payments() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let payment_id2 = client.pay_for_ticket(
         &2,
@@ -584,6 +604,8 @@ fn test_pay_for_ticket_multiple_payments() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let payment_id3 = client.pay_for_ticket(
         &3,
@@ -593,6 +615,8 @@ fn test_pay_for_ticket_multiple_payments() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     assert_eq!(payment_id1, 1);
@@ -601,19 +625,19 @@ fn test_pay_for_ticket_multiple_payments() {
 
     let payment1 = client.get_payment(&payment_id1);
     assert_eq!(payment1.event_id, event_id1);
-    assert_eq!(payment1.payer, payer1);
+    assert_eq!(payment1.payer, Some(payer1.clone()));
     assert_eq!(payment1.amount, amount1);
     assert_eq!(payment1.status, PaymentStatus::Held);
 
     let payment2 = client.get_payment(&payment_id2);
     assert_eq!(payment2.event_id, event_id2);
-    assert_eq!(payment2.payer, payer2);
+    assert_eq!(payment2.payer, Some(payer2.clone()));
     assert_eq!(payment2.amount, amount2);
     assert_eq!(payment2.status, PaymentStatus::Held);
 
     let payment3 = client.get_payment(&payment_id3);
     assert_eq!(payment3.event_id, event_id1);
-    assert_eq!(payment3.payer, payer1);
+    assert_eq!(payment3.payer, Some(payer1.clone()));
     assert_eq!(payment3.amount, amount3);
     assert_eq!(payment3.status, PaymentStatus::Held);
 
@@ -652,6 +676,8 @@ fn test_pay_for_ticket_query_record() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     let payment = env
@@ -660,7 +686,7 @@ fn test_pay_for_ticket_query_record() {
 
     assert_eq!(payment.payment_id, payment_id);
     assert_eq!(payment.event_id, event_id);
-    assert_eq!(payment.payer, payer);
+    assert_eq!(payment.payer, Some(payer.clone()));
     assert_eq!(payment.amount, amount);
     assert_eq!(payment.token, token);
     assert_eq!(payment.status, PaymentStatus::Held);
@@ -690,6 +716,8 @@ fn test_withdraw_revenue_success() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     assert_eq!(token_client.balance(&payer), 0);
@@ -735,6 +763,8 @@ fn test_multiple_withdrawals_tracked() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let _not_admin = Address::generate(&env);
     let result = client.try_refund(&_not_admin, &payment_id, &None);
@@ -763,6 +793,8 @@ fn test_refund_after_withdrawal() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     env.ledger().with_mut(|li| {
         li.sequence_number = 20000;
@@ -778,6 +810,8 @@ fn test_refund_after_withdrawal() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     set_event_status_for_test(&client, &admin, &event_id, &EventStatus::Completed);
     env.ledger().with_mut(|li| {
@@ -820,6 +854,8 @@ fn test_withdraw_happy_path() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let pid2 = client.pay_for_ticket(
         &1,
@@ -829,6 +865,8 @@ fn test_withdraw_happy_path() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     set_event_status_for_test(&client, &admin, &event_id, &EventStatus::Completed);
@@ -897,6 +935,8 @@ fn test_mixed_refund_then_withdraw() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let pid2 = client.pay_for_ticket(
         &1,
@@ -906,6 +946,8 @@ fn test_mixed_refund_then_withdraw() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let pid3 = client.pay_for_ticket(
         &1,
@@ -915,6 +957,8 @@ fn test_mixed_refund_then_withdraw() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     client.refund(&admin, &pid2, &None);
     assert_eq!(client.get_event_revenue(&event_id), amount1 + amount3);
@@ -962,6 +1006,8 @@ fn test_refund_reduces_revenue_correctly() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     client.pay_for_ticket(
         &1,
@@ -971,6 +1017,8 @@ fn test_refund_reduces_revenue_correctly() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     assert_eq!(client.get_event_revenue(&event_id), amount1 + amount2);
@@ -1008,6 +1056,8 @@ fn test_query_payments() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     client.pay_for_ticket(
         &2,
@@ -1017,6 +1067,8 @@ fn test_query_payments() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     client.pay_for_ticket(
         &1,
@@ -1026,6 +1078,8 @@ fn test_query_payments() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     client.pay_for_ticket(
         &2,
@@ -1035,6 +1089,8 @@ fn test_query_payments() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
     let e1_payments = client.get_payments_by_event(&event1);
     assert_eq!(e1_payments.len(), 2);
@@ -1046,8 +1102,8 @@ fn test_query_payments() {
     );
     let p1_payments = client.get_payments_by_user(&payer1);
     assert_eq!(p1_payments.len(), 2);
-    assert_eq!(p1_payments.get(0).unwrap().payer, payer1);
-    assert_eq!(p1_payments.get(1).unwrap().payer, payer1);
+    assert_eq!(p1_payments.get(0).unwrap().payer, Some(payer1.clone()));
+    assert_eq!(p1_payments.get(1).unwrap().payer, Some(payer1.clone()));
     assert_ne!(
         p1_payments.get(0).unwrap().event_id,
         p1_payments.get(1).unwrap().event_id
@@ -1079,6 +1135,8 @@ fn test_pay_for_ticket_with_email_hash() {
         &Some(email_hash.clone()),
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     let payment = client.get_payment(&payment_id);
@@ -1132,6 +1190,8 @@ fn test_release_if_expired_before_deadline_fails() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     client.set_event_end_time(&admin, &event_id, &organizer, &event_end_time);
@@ -1166,6 +1226,8 @@ fn test_release_if_expired_after_deadline_succeeds() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     client.set_event_end_time(&admin, &event_id, &organizer, &event_end_time);
@@ -1207,6 +1269,8 @@ fn test_release_if_expired_no_double_payout() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     client.set_event_end_time(&admin, &event_id, &organizer, &event_end_time);
@@ -1341,11 +1405,18 @@ fn test_pay_for_ticket_anonymous_privacy() {
         &None,
         &token,
         &PaymentPrivacy::Anonymous,
+        &Some(BytesN::from_array(&env, &[7u8; 32])),
+        &None,
     );
 
     let payment = client.get_payment(&payment_id);
     assert_eq!(payment.privacy_level, PaymentPrivacy::Anonymous);
-    assert_eq!(payment.payer, payer);
+    assert_eq!(payment.payer, None);
+    assert_eq!(payment.hashed_wallet, None);
+    assert_eq!(
+        payment.nullifier_commitment,
+        Some(BytesN::from_array(&env, &[7u8; 32]))
+    );
     assert_eq!(payment.amount, amount);
     assert_eq!(payment.status, PaymentStatus::Held);
 }
@@ -1372,11 +1443,19 @@ fn test_pay_for_ticket_private_privacy() {
         &None,
         &token,
         &PaymentPrivacy::Private,
+        &None,
+        &Some(BytesN::from_array(&env, &[9u8; 32])),
     );
 
     let payment = client.get_payment(&payment_id);
     assert_eq!(payment.privacy_level, PaymentPrivacy::Private);
-    assert_eq!(payment.payer, payer);
+    assert_eq!(payment.payer, None);
+    assert!(payment.hashed_wallet.is_some());
+    assert_eq!(
+        payment.stealth_delivery_key,
+        Some(BytesN::from_array(&env, &[9u8; 32]))
+    );
+    assert_eq!(payment.nullifier_commitment, None);
     assert_eq!(payment.amount, amount);
     assert_eq!(payment.status, PaymentStatus::Held);
 }
@@ -1403,11 +1482,15 @@ fn test_pay_for_ticket_standard_privacy() {
         &None,
         &token,
         &PaymentPrivacy::Standard,
+        &None,
+        &None,
     );
 
     let payment = client.get_payment(&payment_id);
     assert_eq!(payment.privacy_level, PaymentPrivacy::Standard);
-    assert_eq!(payment.payer, payer);
+    assert_eq!(payment.payer, Some(payer.clone()));
+    assert_eq!(payment.hashed_wallet, None);
+    assert_eq!(payment.nullifier_commitment, None);
     assert_eq!(payment.amount, amount);
     assert_eq!(payment.status, PaymentStatus::Held);
 }
@@ -1434,10 +1517,15 @@ fn test_anonymous_event_does_not_expose_payer() {
         &None,
         &token,
         &PaymentPrivacy::Anonymous,
+        &Some(BytesN::from_array(&env, &[7u8; 32])),
+        &None,
     );
     let payment = client.get_payment(&payment_id);
     assert_eq!(payment.privacy_level, PaymentPrivacy::Anonymous);
-    assert_eq!(payment.payer, payer);
+    // Anonymous payments store NO raw address on-chain; only the nullifier
+    // commitment is persisted.
+    assert_eq!(payment.payer, None);
+    assert!(payment.nullifier_commitment.is_some());
     assert!(payment_id > 0);
 }
 

--- a/contracts/payments/src/test_privacy_semantics.rs
+++ b/contracts/payments/src/test_privacy_semantics.rs
@@ -1,0 +1,747 @@
+//! Tests for enforceable on-chain payment privacy semantics (Issue #117).
+//!
+//! These tests verify that the three payment privacy levels store, expose, and
+//! refund identity data exactly as their privacy contract requires:
+//! - Standard:  only the raw payer address is stored.
+//! - Private:   only a hashed wallet + stealth delivery key are stored.
+//! - Anonymous: only a nullifier commitment is stored.
+
+use super::*;
+use mock_event_contract::MockEventContract;
+use privacy_utils::MaskedAddress;
+use soroban_sdk::testutils::{Address as _, Events as _};
+use soroban_sdk::xdr::ContractEventBody;
+use soroban_sdk::{
+    symbol_short, token, Address, BytesN, Env, Symbol, TryFromVal, TryIntoVal, Val, Vec as SdkVec,
+};
+
+/// Decode the `MaskedAddress` carried by an event published in the **last**
+/// contract invocation (so call this immediately after `pay_for_ticket`, before
+/// any `get_*` query resets the event buffer). The event is matched on its
+/// `event_type` field (index 0 of the `vec`-format payload); `field_index` is
+/// the position of the masked-identity field. This asserts what actually goes on
+/// the wire, not just what is stored, so a regression in `events.rs` is caught.
+fn emitted_masked_identity(env: &Env, event_type_name: &str, field_index: u32) -> MaskedAddress {
+    let published = env.events().all();
+    for event in published.events().iter() {
+        let ContractEventBody::V0(body) = &event.body;
+        let data_val: Val = match Val::try_from_val(env, &body.data) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let fields: SdkVec<Val> = match data_val.try_into_val(env) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let event_type: Symbol = match fields.get(0).and_then(|v| v.try_into_val(env).ok()) {
+            Some(s) => s,
+            None => continue,
+        };
+        if event_type == Symbol::new(env, event_type_name) {
+            return fields
+                .get(field_index)
+                .unwrap()
+                .try_into_val(env)
+                .expect("masked identity field decodes to MaskedAddress");
+        }
+    }
+    panic!("expected event was not emitted in the last invocation");
+}
+
+/// The masked payer identity emitted in the last `payment_received` event.
+fn emitted_payment_payer(env: &Env) -> MaskedAddress {
+    emitted_masked_identity(env, "payment_received", 3)
+}
+
+/// The masked owner identity emitted in the last `ticket_issued` event.
+fn emitted_ticket_owner(env: &Env) -> MaskedAddress {
+    emitted_masked_identity(env, "ticket_issued", 3)
+}
+
+fn setup(
+    env: &Env,
+) -> (
+    Address,
+    Address,
+    PaymentsContractClient<'_>,
+    Address,
+    token::StellarAssetClient<'_>,
+) {
+    let contract_id = env.register(PaymentsContract, ());
+    let client = PaymentsContractClient::new(env, &contract_id);
+    let event_contract_id = env.register(MockEventContract, ());
+
+    let admin = Address::generate(env);
+    let platform_wallet = Address::generate(env);
+    let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+    let token = token_contract.address();
+    client.initialize(&admin, &token, &0, &platform_wallet, &event_contract_id);
+
+    let token_client = token::StellarAssetClient::new(env, &token);
+    (admin, token, client, contract_id, token_client)
+}
+
+fn fund(env: &Env, admin: &Address, payer: &Address, token: &Address, amount: i128) {
+    let sac = token::StellarAssetClient::new(env, token);
+    sac.mint(admin, &amount);
+    let tc = token::Client::new(env, token);
+    tc.transfer(admin, payer, &amount);
+}
+
+fn commitment(env: &Env) -> BytesN<32> {
+    BytesN::from_array(env, &[7u8; 32])
+}
+
+fn stealth_key(env: &Env) -> BytesN<32> {
+    BytesN::from_array(env, &[9u8; 32])
+}
+
+// ===================== Standard =====================
+
+#[test]
+fn test_standard_stores_payer_address() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let pid = client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Standard,
+        &None,
+        &None,
+    );
+
+    let p = client.get_payment(&pid);
+    assert_eq!(p.payer, Some(payer.clone()));
+    assert_eq!(p.hashed_wallet, None);
+    assert_eq!(p.stealth_delivery_key, None);
+    assert_eq!(p.nullifier_commitment, None);
+}
+
+#[test]
+fn test_standard_emits_payer_address() {
+    // Standard payments index the payer and are queryable by user.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Standard,
+        &None,
+        &None,
+    );
+
+    // Capture emitted identities from the pay invocation before any query
+    // invocation resets the event buffer. Standard payments emit the full address.
+    assert_eq!(
+        emitted_payment_payer(&env),
+        MaskedAddress::Full(payer.clone())
+    );
+    assert_eq!(
+        emitted_ticket_owner(&env),
+        MaskedAddress::Full(payer.clone())
+    );
+
+    let by_user = client.get_payments_by_user(&payer);
+    assert_eq!(by_user.len(), 1);
+    assert_eq!(by_user.get(0).unwrap().payer, Some(payer.clone()));
+
+    let tickets = client.get_owner_tickets(&payer);
+    assert_eq!(tickets.len(), 1);
+    let ticket = client.get_ticket(&tickets.get(0).unwrap());
+    assert_eq!(ticket.owner, Some(payer));
+    assert_eq!(ticket.privacy_level, PaymentPrivacy::Standard);
+}
+
+#[test]
+fn test_standard_event_emits_full_address() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let pid = client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Standard,
+        &None,
+        &None,
+    );
+    // Emitted identity must be the full (unmasked) address — capture it before
+    // the get_payment query invocation resets the event buffer.
+    assert_eq!(
+        emitted_payment_payer(&env),
+        MaskedAddress::Full(payer.clone())
+    );
+    // Standard payment must also retain the full address on-chain.
+    assert_eq!(client.get_payment(&pid).payer, Some(payer));
+}
+
+// ===================== Private =====================
+
+#[test]
+fn test_private_stores_hashed_wallet() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let pid = client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Private,
+        &None,
+        &Some(stealth_key(&env)),
+    );
+
+    let p = client.get_payment(&pid);
+    assert!(p.hashed_wallet.is_some());
+    // The hash is a salted SHA-256 of the payer XDR concatenated with the stealth
+    // delivery key, preventing brute-force enumeration of the payer address.
+    let mut preimage = payer.clone().to_xdr(&env);
+    let key = stealth_key(&env);
+    preimage.append(&soroban_sdk::Bytes::from_slice(
+        &env,
+        key.to_array().as_ref(),
+    ));
+    let expected = env.crypto().sha256(&preimage);
+    assert_eq!(p.hashed_wallet, Some(expected.into()));
+}
+
+#[test]
+fn test_private_no_raw_address_in_record() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let pid = client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Private,
+        &None,
+        &Some(stealth_key(&env)),
+    );
+
+    let p = client.get_payment(&pid);
+    assert_eq!(p.payer, None);
+    assert_eq!(p.nullifier_commitment, None);
+    // Not indexed by raw address -> not discoverable via payer query.
+    assert_eq!(client.get_payments_by_user(&payer).len(), 0);
+    assert_eq!(client.get_owner_tickets(&payer).len(), 0);
+}
+
+#[test]
+fn test_private_requires_stealth_key() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let tc = token::Client::new(&env, &token);
+    let payer_before = tc.balance(&payer);
+    let contract_before = tc.balance(&cid);
+
+    let result = client.try_pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Private,
+        &None,
+        &None,
+    );
+    assert_eq!(
+        result.err(),
+        Some(Ok(PaymentError::MissingStealthDeliveryKey))
+    );
+    // A post-transfer validation failure must not silently debit any funds.
+    assert_eq!(tc.balance(&payer), payer_before);
+    assert_eq!(tc.balance(&cid), contract_before);
+}
+
+#[test]
+fn test_private_stealth_key_stored() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let key = stealth_key(&env);
+    let pid = client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Private,
+        &None,
+        &Some(key.clone()),
+    );
+    assert_eq!(client.get_payment(&pid).stealth_delivery_key, Some(key));
+}
+
+#[test]
+fn test_private_event_hides_raw_address() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let pid = client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Private,
+        &None,
+        &Some(stealth_key(&env)),
+    );
+    // Capture emitted identities before the get_payment query resets the buffer.
+    // The emitted event exposes a hashed wallet — never a full address.
+    let emitted = emitted_payment_payer(&env);
+    let emitted_owner = emitted_ticket_owner(&env);
+    assert!(!matches!(emitted, MaskedAddress::Full(_)));
+    assert!(!matches!(emitted_owner, MaskedAddress::Full(_)));
+
+    // No raw address is recoverable from the stored record, and the emitted
+    // masked identity matches the stored hashed wallet exactly.
+    let stored = client.get_payment(&pid);
+    assert_eq!(stored.payer, None);
+    let hashed = stored
+        .hashed_wallet
+        .expect("private payment stores a hashed wallet");
+    assert_eq!(emitted, MaskedAddress::Hashed(hashed));
+}
+
+// ===================== Anonymous =====================
+
+#[test]
+fn test_anonymous_stores_nullifier_commitment() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let c = commitment(&env);
+    let pid = client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Anonymous,
+        &Some(c.clone()),
+        &None,
+    );
+    assert_eq!(client.get_payment(&pid).nullifier_commitment, Some(c));
+}
+
+#[test]
+fn test_anonymous_no_address_in_record() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let pid = client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Anonymous,
+        &Some(commitment(&env)),
+        &None,
+    );
+    let p = client.get_payment(&pid);
+    assert_eq!(p.payer, None);
+    assert_eq!(client.get_payments_by_user(&payer).len(), 0);
+    assert_eq!(client.get_owner_tickets(&payer).len(), 0);
+}
+
+#[test]
+fn test_anonymous_no_hash_in_record() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let pid = client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Anonymous,
+        &Some(commitment(&env)),
+        &None,
+    );
+    let p = client.get_payment(&pid);
+    assert_eq!(p.hashed_wallet, None);
+    assert_eq!(p.stealth_delivery_key, None);
+}
+
+#[test]
+fn test_anonymous_requires_commitment() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let tc = token::Client::new(&env, &token);
+    let payer_before = tc.balance(&payer);
+    let contract_before = tc.balance(&cid);
+
+    let result = client.try_pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Anonymous,
+        &None,
+        &None,
+    );
+    assert_eq!(
+        result.err(),
+        Some(Ok(PaymentError::MissingNullifierCommitment))
+    );
+    // A post-transfer validation failure must not silently debit any funds.
+    assert_eq!(tc.balance(&payer), payer_before);
+    assert_eq!(tc.balance(&cid), contract_before);
+}
+
+#[test]
+fn test_standard_rejects_privacy_material() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let tc = token::Client::new(&env, &token);
+    let payer_before = tc.balance(&payer);
+    let contract_before = tc.balance(&cid);
+
+    // Privacy material is mutually exclusive: a Standard payment that also
+    // carries Anonymous/Private material is rejected, funds untouched.
+    let result = client.try_pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Standard,
+        &Some(commitment(&env)),
+        &None,
+    );
+    assert_eq!(result.err(), Some(Ok(PaymentError::PrivacyLevelMismatch)));
+    assert_eq!(tc.balance(&payer), payer_before);
+    assert_eq!(tc.balance(&cid), contract_before);
+}
+
+#[test]
+fn test_private_rejects_nullifier_commitment() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    // A Private payment must not carry a nullifier commitment (Anonymous material).
+    let result = client.try_pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Private,
+        &Some(commitment(&env)),
+        &Some(stealth_key(&env)),
+    );
+    assert_eq!(result.err(), Some(Ok(PaymentError::PrivacyLevelMismatch)));
+}
+
+#[test]
+fn test_anonymous_event_no_identity() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let pid = client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Anonymous,
+        &Some(commitment(&env)),
+        &None,
+    );
+    // The emitted events reference only the nullifier commitment — no address,
+    // no wallet hash. Capture them before the get_payment query resets the buffer.
+    let emitted = emitted_payment_payer(&env);
+    assert_eq!(emitted, MaskedAddress::Hashed(commitment(&env)));
+    assert!(!matches!(emitted, MaskedAddress::Full(_)));
+    assert_eq!(
+        emitted_ticket_owner(&env),
+        MaskedAddress::Hashed(commitment(&env))
+    );
+
+    let p = client.get_payment(&pid);
+    assert_eq!(p.payer, None);
+    assert_eq!(p.hashed_wallet, None);
+}
+
+// ===================== Immutability =====================
+
+#[test]
+fn test_no_privacy_level_mutation_path_exists() {
+    // There is no contract function to change a payment's privacy level after
+    // purchase. The privacy level stored at purchase is the final value.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let pid = client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Standard,
+        &None,
+        &None,
+    );
+
+    // The only mutations to a stored payment are status/refund transitions,
+    // never the privacy_level. Confirm it is preserved across a refund.
+    let before = client.get_payment(&pid).privacy_level;
+    client.refund(&admin, &pid, &None);
+    let after = client.get_payment(&pid).privacy_level;
+    assert_eq!(before, after);
+    assert_eq!(after, PaymentPrivacy::Standard);
+}
+
+// ===================== Refund preserves privacy =====================
+
+#[test]
+fn test_anonymous_refund_returns_error() {
+    // Anonymous payments store no payer address, so an on-chain refund would
+    // strand the escrowed tokens. The contract rejects the refund outright.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let pid = client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Anonymous,
+        &Some(commitment(&env)),
+        &None,
+    );
+    let result = client.try_refund(&admin, &pid, &None);
+    assert_eq!(result.err(), Some(Ok(PaymentError::RefundNotAllowed)));
+
+    // Payment remains Held and unchanged.
+    let p = client.get_payment(&pid);
+    assert_eq!(p.status, PaymentStatus::Held);
+    assert_eq!(p.privacy_level, PaymentPrivacy::Anonymous);
+}
+
+#[test]
+fn test_private_refund_returns_error() {
+    // Private payments store only a hashed wallet, so an on-chain refund would
+    // strand the escrowed tokens. The contract rejects the refund outright.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let pid = client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Private,
+        &None,
+        &Some(stealth_key(&env)),
+    );
+    let result = client.try_refund(&admin, &pid, &None);
+    assert_eq!(result.err(), Some(Ok(PaymentError::RefundNotAllowed)));
+
+    // Payment remains Held and unchanged.
+    let p = client.get_payment(&pid);
+    assert_eq!(p.status, PaymentStatus::Held);
+    assert_eq!(p.privacy_level, PaymentPrivacy::Private);
+}
+
+#[test]
+fn test_nullifier_reuse_rejected() {
+    // The same nullifier commitment cannot be spent by two Anonymous payments.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount * 2);
+
+    let c = commitment(&env);
+    client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Anonymous,
+        &Some(c.clone()),
+        &None,
+    );
+
+    let result = client.try_pay_for_ticket(
+        &2,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Anonymous,
+        &Some(c),
+        &None,
+    );
+    assert_eq!(result.err(), Some(Ok(PaymentError::DuplicateRequest)));
+}
+
+#[test]
+fn test_standard_refund_preserves_privacy() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc) = setup(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let amount = 1_000i128;
+    fund(&env, &admin, &payer, &token, amount);
+
+    let pid = client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &amount,
+        &None,
+        &token,
+        &PaymentPrivacy::Standard,
+        &None,
+        &None,
+    );
+    client.refund(&admin, &pid, &None);
+
+    let p = client.get_payment(&pid);
+    assert_eq!(p.status, PaymentStatus::Refunded);
+    assert_eq!(p.privacy_level, PaymentPrivacy::Standard);
+    assert_eq!(p.payer, Some(payer.clone()));
+    // Standard refund returns funds to the on-chain payer.
+    let tc = token::Client::new(&env, &token);
+    assert_eq!(tc.balance(&payer), amount);
+}

--- a/contracts/payments/src/types.rs
+++ b/contracts/payments/src/types.rs
@@ -40,7 +40,11 @@ pub enum PaymentPrivacy {
 pub struct PaymentRecord {
     pub payment_id: u64,
     pub event_id: Symbol,
-    pub payer: Address,
+    // Identity fields — only one set is populated, based on privacy_level:
+    pub payer: Option<Address>,                   // Standard only
+    pub hashed_wallet: Option<BytesN<32>>,        // Private only
+    pub stealth_delivery_key: Option<BytesN<32>>, // Private only
+    pub nullifier_commitment: Option<BytesN<32>>, // Anonymous only
     pub amount: i128,
     pub token: Address,
     pub status: PaymentStatus,
@@ -55,8 +59,11 @@ pub struct PaymentRecord {
 pub struct Ticket {
     pub ticket_id: u64,
     pub event_id: Symbol,
-    pub owner: Address,
+    pub owner: Option<Address>,                   // Standard only
+    pub hashed_owner: Option<BytesN<32>>,         // Private only
+    pub nullifier_commitment: Option<BytesN<32>>, // Anonymous only
     pub payment_id: u64,
+    pub privacy_level: PaymentPrivacy,
 }
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
## Summary

Implements enforceable on-chain semantics for the three payment privacy levels from the spec (Anonymous → Private → Standard), so the privacy slider maps to real contract behaviour instead of UI-only state. Rebased onto the latest `main` with all merge conflicts resolved.

Each `PaymentRecord` / `Ticket` now stores exactly **one** identity representation, chosen by its privacy level:

| Level | Stored on-chain | On-chain refund |
|-------|-----------------|-----------------|
| **Standard** | raw payer address | yes |
| **Private** | salted wallet hash + one-time stealth delivery key | no (off-chain via stealth key) |
| **Anonymous** | nullifier commitment only | no (off-chain via commitment) |

### Key behaviours
- **Immutable** — the privacy level is fixed at purchase; there is no on-chain mutation path.
- **Field exclusivity** — supplying material for a different level (e.g. a commitment on a Standard payment) is rejected with `PrivacyLevelMismatch`.
- **No wallet linkage for Anonymous** — nonce replay-protection and per-user ticket keys derive from the nullifier commitment, never a payer hash; commitment uniqueness blocks reuse.
- **Privacy-aware events** — payment / ticket / refund events emit a masked identity (full / hashed / commitment) taken from the payment's own privacy level, never a raw address for Private/Anonymous.
- **Refunds preserve privacy** — Anonymous/Private payments carry no on-chain address, so on-chain refund paths return `RefundNotAllowed`; settlement happens off-chain.
- **Cross-contract registration** — `register_for_event` enforces the event's configured payment privacy rather than silently downgrading Private/Anonymous events to Standard.

### CodeRabbit review items addressed
- Enforce privacy-material exclusivity in `build_payment_record`.
- Stop persisting payer-derived keys for Anonymous nonce / ticket counters.
- Reject (don't silently downgrade) Private/Anonymous events in `register_for_event`.
- Event tests assert the emitted `MaskedAddress`, not just stored state.
- Rejected-purchase tests assert balances are unchanged (no silent debit).

## Tests
New `test_privacy_semantics.rs` plus updates covering field exclusivity, missing-field rejection, nullifier reuse, refund guards, immutability, emitted-event identity, and balance-safety on failed purchases. Full workspace suite green; `cargo fmt` and `cargo clippy -D warnings` clean.

## Known limitation
`require_auth()` runs for every privacy level because the token transfer needs wallet authorization, so the submitting account is visible in the Stellar transaction envelope regardless of level. Anonymous/Private privacy applies at the contract storage and event layer only; transaction-level anonymity would require a relayer / meta-transaction model, which is out of scope for this issue.

Closes #117


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end payment privacy handling across Standard, Private, and Anonymous flows, including privacy-appropriate identity in emitted payment/ticket events.
  * Enhanced privacy checks for event registration and zk attendance, rejecting unsupported private/anonymous settlement paths.
* **Bug Fixes**
  * Added new error reporting for privacy/settlement and payment privacy validation mismatches.
  * Updated refunds/resale/payment identity rules to preserve privacy level and avoid exposing unavailable payer data.
* **Tests**
  * Added and updated privacy semantics and registration rejection coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->