### PR TITLE
docs: restore 2 dead link(s) via Wayback

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ zicket-contract/
 ## Prerequisites
 
 - [Rust](https://www.rust-lang.org/tools/install) (latest stable)
-- [Soroban CLI](https://soroban.stellar.org/docs/getting-started/setup)
-- [Stellar CLI](https://developers.stellar.org/docs/tools/developer-tools/cli/stellar-cli) (optional, for deployment)
+- [Soroban CLI](http://web.archive.org/web/20240222012504/https://soroban.stellar.org/docs/getting-started/setup)
+- [Stellar CLI](http://web.archive.org/web/20250227044257/https://developers.stellar.org/docs/tools/developer-tools/cli/stellar-cli) (optional, for deployment)
 
 ## Getting Started
 


### PR DESCRIPTION
This PR fixes 2 broken outbound documentation link(s).

Changes:
- `README.md`: `https://soroban.stellar.org/docs/getting-started/setup` → `http://web.archive.org/web/20240222012504/https://soroban.stellar.org/` (Wayback snapshot (host dead))
- `README.md`: `https://developers.stellar.org/docs/tools/developer-tools/cli/stellar-` → `http://web.archive.org/web/20250227044257/https://developers.stellar.o` (Wayback snapshot (host dead))

Fixes #44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated prerequisite links for the Soroban CLI and Stellar CLI documentation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->