### PR TITLE
feat(payments): implement attendee-initiated dispute resolution and refund hooks

### DIFF
--- a/contracts/payments/src/errors.rs
+++ b/contracts/payments/src/errors.rs
@@ -74,4 +74,6 @@ pub enum PaymentError {
     DisputeExpired = 49,
     /// Invalid reason code provided for dispute.
     InvalidDisputeReason = 50,
+    /// Organizer cannot withdraw while disputes are active.
+    ActiveDisputes = 51,
 }

--- a/contracts/payments/src/errors.rs
+++ b/contracts/payments/src/errors.rs
@@ -1,4 +1,4 @@
-﻿use soroban_sdk::contracterror;
+use soroban_sdk::contracterror;
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -64,4 +64,14 @@ pub enum PaymentError {
     MissingStealthDeliveryKey = 44,
     /// The supplied privacy data does not match the declared privacy level
     PrivacyLevelMismatch = 45,
+    /// The dispute window is closed or not open yet.
+    DisputeWindowClosed = 46,
+    /// A dispute already exists for this ticket.
+    DisputeAlreadyExists = 47,
+    /// No dispute record was found for this ticket.
+    DisputeNotFound = 48,
+    /// The dispute resolution timeout has expired.
+    DisputeExpired = 49,
+    /// Invalid reason code provided for dispute.
+    InvalidDisputeReason = 50,
 }

--- a/contracts/payments/src/events.rs
+++ b/contracts/payments/src/events.rs
@@ -349,3 +349,78 @@ pub fn emit_flagged_share_resolved(
     }
     .publish(env);
 }
+
+#[contractevent(data_format = "vec", topics = ["dispute_raised"])]
+pub struct DisputeRaised {
+    pub event_type: Symbol,
+    pub event_id: Symbol,
+    pub ticket_id: u64,
+    pub payment_id: u64,
+    pub reason_code: u32,
+    pub raised_at: u64,
+}
+
+pub fn emit_dispute_raised(
+    env: &Env,
+    event_id: Symbol,
+    ticket_id: u64,
+    payment_id: u64,
+    reason_code: u32,
+) {
+    DisputeRaised {
+        event_type: event_type(env, "dispute_raised"),
+        event_id,
+        ticket_id,
+        payment_id,
+        reason_code,
+        raised_at: env.ledger().timestamp(),
+    }
+    .publish(env);
+}
+
+#[contractevent(data_format = "vec", topics = ["dispute_resolved"])]
+pub struct DisputeResolved {
+    pub event_type: Symbol,
+    pub event_id: Symbol,
+    pub ticket_id: u64,
+    pub refund_approved: bool,
+    pub resolved_at: u64,
+}
+
+pub fn emit_dispute_resolved(
+    env: &Env,
+    event_id: Symbol,
+    ticket_id: u64,
+    refund_approved: bool,
+) {
+    DisputeResolved {
+        event_type: event_type(env, "dispute_resolved"),
+        event_id,
+        ticket_id,
+        refund_approved,
+        resolved_at: env.ledger().timestamp(),
+    }
+    .publish(env);
+}
+
+#[contractevent(data_format = "vec", topics = ["dispute_timed_out"])]
+pub struct DisputeTimedOut {
+    pub event_type: Symbol,
+    pub event_id: Symbol,
+    pub ticket_id: u64,
+    pub timed_out_at: u64,
+}
+
+pub fn emit_dispute_timed_out(
+    env: &Env,
+    event_id: Symbol,
+    ticket_id: u64,
+) {
+    DisputeTimedOut {
+        event_type: event_type(env, "dispute_timed_out"),
+        event_id,
+        ticket_id,
+        timed_out_at: env.ledger().timestamp(),
+    }
+    .publish(env);
+}

--- a/contracts/payments/src/events.rs
+++ b/contracts/payments/src/events.rs
@@ -387,12 +387,7 @@ pub struct DisputeResolved {
     pub resolved_at: u64,
 }
 
-pub fn emit_dispute_resolved(
-    env: &Env,
-    event_id: Symbol,
-    ticket_id: u64,
-    refund_approved: bool,
-) {
+pub fn emit_dispute_resolved(env: &Env, event_id: Symbol, ticket_id: u64, refund_approved: bool) {
     DisputeResolved {
         event_type: event_type(env, "dispute_resolved"),
         event_id,
@@ -411,11 +406,7 @@ pub struct DisputeTimedOut {
     pub timed_out_at: u64,
 }
 
-pub fn emit_dispute_timed_out(
-    env: &Env,
-    event_id: Symbol,
-    ticket_id: u64,
-) {
+pub fn emit_dispute_timed_out(env: &Env, event_id: Symbol, ticket_id: u64) {
     DisputeTimedOut {
         event_type: event_type(env, "dispute_timed_out"),
         event_id,

--- a/contracts/payments/src/lib.rs
+++ b/contracts/payments/src/lib.rs
@@ -192,8 +192,14 @@ fn process_timed_out_disputes(env: &Env, event_id: &Symbol) -> Result<(), Paymen
                             storage::update_payment(env, &payment)?;
                             let rev = storage::get_event_revenue(env, event_id);
                             storage::set_event_revenue(env, event_id, rev + payment.amount);
-                            let token_rev = storage::get_event_token_revenue(env, event_id, &payment.token);
-                            storage::set_event_token_revenue(env, event_id, &payment.token, token_rev + payment.amount);
+                            let token_rev =
+                                storage::get_event_token_revenue(env, event_id, &payment.token);
+                            storage::set_event_token_revenue(
+                                env,
+                                event_id,
+                                &payment.token,
+                                token_rev + payment.amount,
+                            );
                         }
                     }
                     storage::remove_dispute(env, ticket_id);
@@ -246,7 +252,9 @@ fn validate_revenue_invariant(env: &Env, event_id: &Symbol) -> Result<(), Paymen
 
     let platform_revenue = storage::get_platform_revenue(env, event_id);
 
-    if total_payments != current_revenue + total_refunds + total_withdrawn + platform_revenue + total_disputed {
+    if total_payments
+        != current_revenue + total_refunds + total_withdrawn + platform_revenue + total_disputed
+    {
         return Err(PaymentError::AccountingMismatch);
     }
     let tokens = storage::get_event_tokens(env, event_id);
@@ -503,7 +511,10 @@ fn collect_cancellation_organizer_pool(
             .get(index)
             .ok_or(PaymentError::PaymentNotFound)?;
         let payment = storage::get_payment(env, payment_id)?;
-        if payment.token == *token_address && payment.status != PaymentStatus::Released && payment.status != PaymentStatus::Disputed {
+        if payment.token == *token_address
+            && payment.status != PaymentStatus::Released
+            && payment.status != PaymentStatus::Disputed
+        {
             total += payment.amount * (withdrawable_ratio_bps as i128) / 10_000;
         }
     }
@@ -2334,11 +2345,7 @@ impl PaymentsContract {
         Ok(())
     }
 
-    pub fn raise_dispute(
-        env: Env,
-        ticket_id: u64,
-        reason_code: u32,
-    ) -> Result<(), PaymentError> {
+    pub fn raise_dispute(env: Env, ticket_id: u64, reason_code: u32) -> Result<(), PaymentError> {
         require_not_paused(&env)?;
         if reason_code > 2 {
             return Err(PaymentError::InvalidDisputeReason);
@@ -2377,7 +2384,12 @@ impl PaymentsContract {
         let rev = storage::get_event_revenue(&env, &ticket.event_id);
         storage::set_event_revenue(&env, &ticket.event_id, rev - payment.amount);
         let token_rev = storage::get_event_token_revenue(&env, &ticket.event_id, &payment.token);
-        storage::set_event_token_revenue(&env, &ticket.event_id, &payment.token, token_rev - payment.amount);
+        storage::set_event_token_revenue(
+            &env,
+            &ticket.event_id,
+            &payment.token,
+            token_rev - payment.amount,
+        );
 
         let dispute = DisputeRecord {
             ticket_id,
@@ -2392,20 +2404,22 @@ impl PaymentsContract {
         disputes.push_back(ticket_id);
         storage::set_event_disputes(&env, &ticket.event_id, &disputes);
 
-        events::emit_dispute_raised(&env, ticket.event_id, ticket_id, payment.payment_id, reason_code);
+        events::emit_dispute_raised(
+            &env,
+            ticket.event_id,
+            ticket_id,
+            payment.payment_id,
+            reason_code,
+        );
         Ok(())
     }
 
-    pub fn approve_refund(
-        env: Env,
-        ticket_id: u64,
-    ) -> Result<(), PaymentError> {
+    pub fn approve_refund(env: Env, ticket_id: u64) -> Result<(), PaymentError> {
         require_not_paused(&env)?;
         let admin = storage::get_admin(&env)?;
         admin.require_auth();
 
-        let dispute = storage::get_dispute(&env, ticket_id)
-            .ok_or(PaymentError::DisputeNotFound)?;
+        let dispute = storage::get_dispute(&env, ticket_id).ok_or(PaymentError::DisputeNotFound)?;
 
         if env.ledger().sequence() >= dispute.raised_at_ledger + DISPUTE_TIMEOUT_LEDGERS {
             return Err(PaymentError::DisputeExpired);
@@ -2442,16 +2456,12 @@ impl PaymentsContract {
         Ok(())
     }
 
-    pub fn reject_dispute(
-        env: Env,
-        ticket_id: u64,
-    ) -> Result<(), PaymentError> {
+    pub fn reject_dispute(env: Env, ticket_id: u64) -> Result<(), PaymentError> {
         require_not_paused(&env)?;
         let admin = storage::get_admin(&env)?;
         admin.require_auth();
 
-        let dispute = storage::get_dispute(&env, ticket_id)
-            .ok_or(PaymentError::DisputeNotFound)?;
+        let dispute = storage::get_dispute(&env, ticket_id).ok_or(PaymentError::DisputeNotFound)?;
 
         let mut payment = storage::get_payment(&env, dispute.payment_id)?;
         if payment.status != PaymentStatus::Disputed {
@@ -2464,7 +2474,12 @@ impl PaymentsContract {
         let rev = storage::get_event_revenue(&env, &dispute.event_id);
         storage::set_event_revenue(&env, &dispute.event_id, rev + payment.amount);
         let token_rev = storage::get_event_token_revenue(&env, &dispute.event_id, &payment.token);
-        storage::set_event_token_revenue(&env, &dispute.event_id, &payment.token, token_rev + payment.amount);
+        storage::set_event_token_revenue(
+            &env,
+            &dispute.event_id,
+            &payment.token,
+            token_rev + payment.amount,
+        );
 
         storage::remove_dispute(&env, ticket_id);
         let disputes = storage::get_event_disputes(&env, &dispute.event_id);
@@ -2496,6 +2511,6 @@ mod revenue_split_test;
 #[cfg(test)]
 mod test;
 #[cfg(test)]
-mod test_privacy_semantics;
-#[cfg(test)]
 mod test_disputes;
+#[cfg(test)]
+mod test_privacy_semantics;

--- a/contracts/payments/src/lib.rs
+++ b/contracts/payments/src/lib.rs
@@ -185,7 +185,7 @@ fn process_timed_out_disputes(env: &Env, event_id: &Symbol) -> Result<(), Paymen
     for i in 0..disputes.len() {
         if let Some(ticket_id) = disputes.get(i) {
             if let Some(dispute) = storage::get_dispute(env, ticket_id) {
-                if env.ledger().sequence() >= dispute.raised_at_ledger + DISPUTE_TIMEOUT_LEDGERS {
+                if env.ledger().sequence() >= dispute.raised_at_ledger.saturating_add(DISPUTE_TIMEOUT_LEDGERS) {
                     if let Ok(mut payment) = storage::get_payment(env, dispute.payment_id) {
                         if payment.status == PaymentStatus::Disputed {
                             payment.status = PaymentStatus::Held;
@@ -613,6 +613,11 @@ fn ensure_split_settled(env: &Env, event_id: &Symbol) -> Result<SplitSettlement,
     }
 
     validate_revenue_invariant(env, event_id)?;
+
+    let disputes = storage::get_event_disputes(env, event_id);
+    if disputes.len() > 0 {
+        return Err(PaymentError::ActiveDisputes);
+    }
 
     let payout_token = storage::get_event_payout_token(env, event_id)?;
     let is_cancelled = storage::get_event_status(env, event_id) == Some(EventStatus::Cancelled);
@@ -1083,6 +1088,11 @@ impl PaymentsContract {
         }
 
         validate_revenue_invariant(&env, &event_id)?;
+
+        let disputes = storage::get_event_disputes(&env, &event_id);
+        if disputes.len() > 0 {
+            return Err(PaymentError::ActiveDisputes);
+        }
 
         let payout_token = storage::get_event_payout_token(&env, &event_id)?;
         let revenue = storage::get_event_token_revenue(&env, &event_id, &payout_token);
@@ -2345,7 +2355,7 @@ impl PaymentsContract {
         Ok(())
     }
 
-    pub fn raise_dispute(env: Env, ticket_id: u64, reason_code: u32) -> Result<(), PaymentError> {
+    pub fn raise_dispute(env: Env, ticket_id: u64, reason_code: u32, proof: Option<Bytes>) -> Result<(), PaymentError> {
         require_not_paused(&env)?;
         if reason_code > 2 {
             return Err(PaymentError::InvalidDisputeReason);
@@ -2355,7 +2365,25 @@ impl PaymentsContract {
         if ticket.privacy_level == PaymentPrivacy::Standard {
             if let Some(ref owner) = ticket.owner {
                 owner.require_auth();
+            } else {
+                return Err(PaymentError::Unauthorized);
             }
+        } else if ticket.privacy_level == PaymentPrivacy::Anonymous {
+            let preimage = proof.ok_or(PaymentError::Unauthorized)?;
+            let hash = env.crypto().sha256(&preimage);
+            if Some(hash.into()) != ticket.nullifier_commitment {
+                return Err(PaymentError::Unauthorized);
+            }
+        } else if ticket.privacy_level == PaymentPrivacy::Private {
+            let signature = proof.ok_or(PaymentError::Unauthorized)?;
+            let pub_key = ticket.stealth_delivery_key.ok_or(PaymentError::Unauthorized)?;
+            let mut msg = Bytes::new(&env);
+            msg.append(&ticket_id.to_xdr(&env));
+            if signature.len() != 64 {
+                return Err(PaymentError::Unauthorized);
+            }
+            let sig_bytes: BytesN<64> = signature.try_into().map_err(|_| PaymentError::Unauthorized)?;
+            env.crypto().ed25519_verify(&pub_key, &msg, &sig_bytes);
         }
 
         let config = storage::get_event_config(&env, &ticket.event_id)
@@ -2365,7 +2393,7 @@ impl PaymentsContract {
         if current_ledger < config.event_end_ledger {
             return Err(PaymentError::DisputeWindowClosed);
         }
-        if current_ledger >= config.event_end_ledger + ATTENDEE_DISPUTE_WINDOW_LEDGERS {
+        if current_ledger >= config.event_end_ledger.saturating_add(ATTENDEE_DISPUTE_WINDOW_LEDGERS) {
             return Err(PaymentError::DisputeWindowClosed);
         }
 
@@ -2421,7 +2449,7 @@ impl PaymentsContract {
 
         let dispute = storage::get_dispute(&env, ticket_id).ok_or(PaymentError::DisputeNotFound)?;
 
-        if env.ledger().sequence() >= dispute.raised_at_ledger + DISPUTE_TIMEOUT_LEDGERS {
+        if env.ledger().sequence() >= dispute.raised_at_ledger.saturating_add(DISPUTE_TIMEOUT_LEDGERS) {
             return Err(PaymentError::DisputeExpired);
         }
 
@@ -2434,6 +2462,8 @@ impl PaymentsContract {
         if let Some(refund_to) = payment.payer.clone() {
             let token_client = token::Client::new(&env, &payment.token);
             token_client.transfer(&env.current_contract_address(), &refund_to, &remaining);
+        } else {
+            return Err(PaymentError::RefundNotAllowed);
         }
 
         payment.refunded_amount += remaining;

--- a/contracts/payments/src/lib.rs
+++ b/contracts/payments/src/lib.rs
@@ -18,6 +18,8 @@ pub use events::*;
 pub use storage::*;
 pub use types::*;
 const MIN_DISPUTE_WINDOW_LEDGERS: u32 = 100;
+const ATTENDEE_DISPUTE_WINDOW_LEDGERS: u32 = 17_280 * 7;
+const DISPUTE_TIMEOUT_LEDGERS: u32 = 17_280 * 14;
 
 #[derive(Clone)]
 struct PaymentParams {
@@ -173,14 +175,52 @@ fn validate_payment_privacy(
     Ok(())
 }
 
+fn process_timed_out_disputes(env: &Env, event_id: &Symbol) -> Result<(), PaymentError> {
+    let disputes = storage::get_event_disputes(env, event_id);
+    if disputes.is_empty() {
+        return Ok(());
+    }
+    let mut remaining = soroban_sdk::Vec::new(env);
+    let mut modified = false;
+    for i in 0..disputes.len() {
+        if let Some(ticket_id) = disputes.get(i) {
+            if let Some(dispute) = storage::get_dispute(env, ticket_id) {
+                if env.ledger().sequence() >= dispute.raised_at_ledger + DISPUTE_TIMEOUT_LEDGERS {
+                    if let Ok(mut payment) = storage::get_payment(env, dispute.payment_id) {
+                        if payment.status == PaymentStatus::Disputed {
+                            payment.status = PaymentStatus::Held;
+                            storage::update_payment(env, &payment)?;
+                            let rev = storage::get_event_revenue(env, event_id);
+                            storage::set_event_revenue(env, event_id, rev + payment.amount);
+                            let token_rev = storage::get_event_token_revenue(env, event_id, &payment.token);
+                            storage::set_event_token_revenue(env, event_id, &payment.token, token_rev + payment.amount);
+                        }
+                    }
+                    storage::remove_dispute(env, ticket_id);
+                    events::emit_dispute_timed_out(env, event_id.clone(), ticket_id);
+                    modified = true;
+                } else {
+                    remaining.push_back(ticket_id);
+                }
+            }
+        }
+    }
+    if modified {
+        storage::set_event_disputes(env, event_id, &remaining);
+    }
+    Ok(())
+}
+
 fn validate_revenue_invariant(env: &Env, event_id: &Symbol) -> Result<(), PaymentError> {
     if let Some(EventStatus::Cancelled) = storage::get_event_status(env, event_id) {
         return Ok(());
     }
+    process_timed_out_disputes(env, event_id)?;
 
     let payment_ids = storage::get_event_payments(env, event_id);
     let mut total_payments: i128 = 0;
     let mut total_refunds: i128 = 0;
+    let mut total_disputed: i128 = 0;
 
     for i in 0..payment_ids.len() {
         if let Some(pid) = payment_ids.get(i) {
@@ -188,6 +228,8 @@ fn validate_revenue_invariant(env: &Env, event_id: &Symbol) -> Result<(), Paymen
                 total_payments += payment.amount;
                 if payment.status == PaymentStatus::Refunded {
                     total_refunds += payment.amount;
+                } else if payment.status == PaymentStatus::Disputed {
+                    total_disputed += payment.amount;
                 }
             }
         }
@@ -204,7 +246,7 @@ fn validate_revenue_invariant(env: &Env, event_id: &Symbol) -> Result<(), Paymen
 
     let platform_revenue = storage::get_platform_revenue(env, event_id);
 
-    if total_payments != current_revenue + total_refunds + total_withdrawn + platform_revenue {
+    if total_payments != current_revenue + total_refunds + total_withdrawn + platform_revenue + total_disputed {
         return Err(PaymentError::AccountingMismatch);
     }
     let tokens = storage::get_event_tokens(env, event_id);
@@ -461,7 +503,7 @@ fn collect_cancellation_organizer_pool(
             .get(index)
             .ok_or(PaymentError::PaymentNotFound)?;
         let payment = storage::get_payment(env, payment_id)?;
-        if payment.token == *token_address && payment.status != PaymentStatus::Released {
+        if payment.token == *token_address && payment.status != PaymentStatus::Released && payment.status != PaymentStatus::Disputed {
             total += payment.amount * (withdrawable_ratio_bps as i128) / 10_000;
         }
     }
@@ -2291,6 +2333,158 @@ impl PaymentsContract {
 
         Ok(())
     }
+
+    pub fn raise_dispute(
+        env: Env,
+        ticket_id: u64,
+        reason_code: u32,
+    ) -> Result<(), PaymentError> {
+        require_not_paused(&env)?;
+        if reason_code > 2 {
+            return Err(PaymentError::InvalidDisputeReason);
+        }
+
+        let ticket = storage::get_ticket(&env, ticket_id)?;
+        if ticket.privacy_level == PaymentPrivacy::Standard {
+            if let Some(ref owner) = ticket.owner {
+                owner.require_auth();
+            }
+        }
+
+        let config = storage::get_event_config(&env, &ticket.event_id)
+            .ok_or(PaymentError::InvalidOrganizer)?;
+
+        let current_ledger = env.ledger().sequence();
+        if current_ledger < config.event_end_ledger {
+            return Err(PaymentError::DisputeWindowClosed);
+        }
+        if current_ledger >= config.event_end_ledger + ATTENDEE_DISPUTE_WINDOW_LEDGERS {
+            return Err(PaymentError::DisputeWindowClosed);
+        }
+
+        if storage::get_dispute(&env, ticket_id).is_some() {
+            return Err(PaymentError::DisputeAlreadyExists);
+        }
+
+        let mut payment = storage::get_payment(&env, ticket.payment_id)?;
+        if payment.status != PaymentStatus::Held {
+            return Err(PaymentError::PaymentAlreadyProcessed);
+        }
+
+        payment.status = PaymentStatus::Disputed;
+        storage::update_payment(&env, &payment)?;
+
+        let rev = storage::get_event_revenue(&env, &ticket.event_id);
+        storage::set_event_revenue(&env, &ticket.event_id, rev - payment.amount);
+        let token_rev = storage::get_event_token_revenue(&env, &ticket.event_id, &payment.token);
+        storage::set_event_token_revenue(&env, &ticket.event_id, &payment.token, token_rev - payment.amount);
+
+        let dispute = DisputeRecord {
+            ticket_id,
+            event_id: ticket.event_id.clone(),
+            payment_id: payment.payment_id,
+            reason_code,
+            raised_at_ledger: current_ledger,
+        };
+        storage::set_dispute(&env, ticket_id, &dispute);
+
+        let mut disputes = storage::get_event_disputes(&env, &ticket.event_id);
+        disputes.push_back(ticket_id);
+        storage::set_event_disputes(&env, &ticket.event_id, &disputes);
+
+        events::emit_dispute_raised(&env, ticket.event_id, ticket_id, payment.payment_id, reason_code);
+        Ok(())
+    }
+
+    pub fn approve_refund(
+        env: Env,
+        ticket_id: u64,
+    ) -> Result<(), PaymentError> {
+        require_not_paused(&env)?;
+        let admin = storage::get_admin(&env)?;
+        admin.require_auth();
+
+        let dispute = storage::get_dispute(&env, ticket_id)
+            .ok_or(PaymentError::DisputeNotFound)?;
+
+        if env.ledger().sequence() >= dispute.raised_at_ledger + DISPUTE_TIMEOUT_LEDGERS {
+            return Err(PaymentError::DisputeExpired);
+        }
+
+        let mut payment = storage::get_payment(&env, dispute.payment_id)?;
+        if payment.status != PaymentStatus::Disputed {
+            return Err(PaymentError::PaymentAlreadyProcessed);
+        }
+
+        let remaining = payment.amount - payment.refunded_amount;
+        if let Some(refund_to) = payment.payer.clone() {
+            let token_client = token::Client::new(&env, &payment.token);
+            token_client.transfer(&env.current_contract_address(), &refund_to, &remaining);
+        }
+
+        payment.refunded_amount += remaining;
+        payment.status = PaymentStatus::Refunded;
+        storage::update_payment(&env, &payment)?;
+
+        storage::remove_dispute(&env, ticket_id);
+        let disputes = storage::get_event_disputes(&env, &dispute.event_id);
+        let mut new_disputes = soroban_sdk::Vec::new(&env);
+        for i in 0..disputes.len() {
+            if let Some(tid) = disputes.get(i) {
+                if tid != ticket_id {
+                    new_disputes.push_back(tid);
+                }
+            }
+        }
+        storage::set_event_disputes(&env, &dispute.event_id, &new_disputes);
+
+        events::emit_dispute_resolved(&env, dispute.event_id, ticket_id, true);
+        Ok(())
+    }
+
+    pub fn reject_dispute(
+        env: Env,
+        ticket_id: u64,
+    ) -> Result<(), PaymentError> {
+        require_not_paused(&env)?;
+        let admin = storage::get_admin(&env)?;
+        admin.require_auth();
+
+        let dispute = storage::get_dispute(&env, ticket_id)
+            .ok_or(PaymentError::DisputeNotFound)?;
+
+        let mut payment = storage::get_payment(&env, dispute.payment_id)?;
+        if payment.status != PaymentStatus::Disputed {
+            return Err(PaymentError::PaymentAlreadyProcessed);
+        }
+
+        payment.status = PaymentStatus::Held;
+        storage::update_payment(&env, &payment)?;
+
+        let rev = storage::get_event_revenue(&env, &dispute.event_id);
+        storage::set_event_revenue(&env, &dispute.event_id, rev + payment.amount);
+        let token_rev = storage::get_event_token_revenue(&env, &dispute.event_id, &payment.token);
+        storage::set_event_token_revenue(&env, &dispute.event_id, &payment.token, token_rev + payment.amount);
+
+        storage::remove_dispute(&env, ticket_id);
+        let disputes = storage::get_event_disputes(&env, &dispute.event_id);
+        let mut new_disputes = soroban_sdk::Vec::new(&env);
+        for i in 0..disputes.len() {
+            if let Some(tid) = disputes.get(i) {
+                if tid != ticket_id {
+                    new_disputes.push_back(tid);
+                }
+            }
+        }
+        storage::set_event_disputes(&env, &dispute.event_id, &new_disputes);
+
+        events::emit_dispute_resolved(&env, dispute.event_id, ticket_id, false);
+        Ok(())
+    }
+
+    pub fn process_dispute_timeouts(env: Env, event_id: Symbol) -> Result<(), PaymentError> {
+        process_timed_out_disputes(&env, &event_id)
+    }
 }
 
 #[cfg(test)]
@@ -2303,3 +2497,5 @@ mod revenue_split_test;
 mod test;
 #[cfg(test)]
 mod test_privacy_semantics;
+#[cfg(test)]
+mod test_disputes;

--- a/contracts/payments/src/lib.rs
+++ b/contracts/payments/src/lib.rs
@@ -185,7 +185,11 @@ fn process_timed_out_disputes(env: &Env, event_id: &Symbol) -> Result<(), Paymen
     for i in 0..disputes.len() {
         if let Some(ticket_id) = disputes.get(i) {
             if let Some(dispute) = storage::get_dispute(env, ticket_id) {
-                if env.ledger().sequence() >= dispute.raised_at_ledger.saturating_add(DISPUTE_TIMEOUT_LEDGERS) {
+                if env.ledger().sequence()
+                    >= dispute
+                        .raised_at_ledger
+                        .saturating_add(DISPUTE_TIMEOUT_LEDGERS)
+                {
                     if let Ok(mut payment) = storage::get_payment(env, dispute.payment_id) {
                         if payment.status == PaymentStatus::Disputed {
                             payment.status = PaymentStatus::Held;
@@ -615,7 +619,7 @@ fn ensure_split_settled(env: &Env, event_id: &Symbol) -> Result<SplitSettlement,
     validate_revenue_invariant(env, event_id)?;
 
     let disputes = storage::get_event_disputes(env, event_id);
-    if disputes.len() > 0 {
+    if !disputes.is_empty() {
         return Err(PaymentError::ActiveDisputes);
     }
 
@@ -1090,7 +1094,7 @@ impl PaymentsContract {
         validate_revenue_invariant(&env, &event_id)?;
 
         let disputes = storage::get_event_disputes(&env, &event_id);
-        if disputes.len() > 0 {
+        if !disputes.is_empty() {
             return Err(PaymentError::ActiveDisputes);
         }
 
@@ -2355,7 +2359,12 @@ impl PaymentsContract {
         Ok(())
     }
 
-    pub fn raise_dispute(env: Env, ticket_id: u64, reason_code: u32, proof: Option<Bytes>) -> Result<(), PaymentError> {
+    pub fn raise_dispute(
+        env: Env,
+        ticket_id: u64,
+        reason_code: u32,
+        proof: Option<Bytes>,
+    ) -> Result<(), PaymentError> {
         require_not_paused(&env)?;
         if reason_code > 2 {
             return Err(PaymentError::InvalidDisputeReason);
@@ -2376,13 +2385,18 @@ impl PaymentsContract {
             }
         } else if ticket.privacy_level == PaymentPrivacy::Private {
             let signature = proof.ok_or(PaymentError::Unauthorized)?;
-            let pub_key = ticket.stealth_delivery_key.ok_or(PaymentError::Unauthorized)?;
+            let payment = storage::get_payment(&env, ticket.payment_id)?;
+            let pub_key = payment
+                .stealth_delivery_key
+                .ok_or(PaymentError::Unauthorized)?;
             let mut msg = Bytes::new(&env);
             msg.append(&ticket_id.to_xdr(&env));
             if signature.len() != 64 {
                 return Err(PaymentError::Unauthorized);
             }
-            let sig_bytes: BytesN<64> = signature.try_into().map_err(|_| PaymentError::Unauthorized)?;
+            let sig_bytes: BytesN<64> = signature
+                .try_into()
+                .map_err(|_| PaymentError::Unauthorized)?;
             env.crypto().ed25519_verify(&pub_key, &msg, &sig_bytes);
         }
 
@@ -2393,7 +2407,11 @@ impl PaymentsContract {
         if current_ledger < config.event_end_ledger {
             return Err(PaymentError::DisputeWindowClosed);
         }
-        if current_ledger >= config.event_end_ledger.saturating_add(ATTENDEE_DISPUTE_WINDOW_LEDGERS) {
+        if current_ledger
+            >= config
+                .event_end_ledger
+                .saturating_add(ATTENDEE_DISPUTE_WINDOW_LEDGERS)
+        {
             return Err(PaymentError::DisputeWindowClosed);
         }
 
@@ -2449,7 +2467,11 @@ impl PaymentsContract {
 
         let dispute = storage::get_dispute(&env, ticket_id).ok_or(PaymentError::DisputeNotFound)?;
 
-        if env.ledger().sequence() >= dispute.raised_at_ledger.saturating_add(DISPUTE_TIMEOUT_LEDGERS) {
+        if env.ledger().sequence()
+            >= dispute
+                .raised_at_ledger
+                .saturating_add(DISPUTE_TIMEOUT_LEDGERS)
+        {
             return Err(PaymentError::DisputeExpired);
         }
 

--- a/contracts/payments/src/storage.rs
+++ b/contracts/payments/src/storage.rs
@@ -84,6 +84,10 @@ pub enum DataKey {
     UserEventTicketsHash(Symbol, BytesN<32>),
     /// Records a spent nullifier commitment to guarantee Anonymous-payment uniqueness.
     SpentNullifier(BytesN<32>),
+    /// Dispute record keyed by ticket id.
+    Dispute(u64),
+    /// List of disputed ticket ids for an event.
+    EventDisputes(Symbol),
 }
 
 pub fn set_event_status(env: &Env, event_id: &Symbol, status: &EventStatus) {
@@ -816,4 +820,37 @@ pub fn get_resale_listing(env: &Env, ticket_id: u64) -> Option<crate::types::Res
 pub fn remove_resale_listing(env: &Env, ticket_id: u64) {
     let key = DataKey::ResaleListing(ticket_id);
     env.storage().persistent().remove(&key);
+}
+
+pub fn get_dispute(env: &Env, ticket_id: u64) -> Option<crate::types::DisputeRecord> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Dispute(ticket_id))
+}
+
+pub fn set_dispute(env: &Env, ticket_id: u64, record: &crate::types::DisputeRecord) {
+    let key = DataKey::Dispute(ticket_id);
+    env.storage().persistent().set(&key, record);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, TTL_THRESHOLD, TTL_BUMP);
+}
+
+pub fn remove_dispute(env: &Env, ticket_id: u64) {
+    env.storage().persistent().remove(&DataKey::Dispute(ticket_id));
+}
+
+pub fn get_event_disputes(env: &Env, event_id: &Symbol) -> soroban_sdk::Vec<u64> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::EventDisputes(event_id.clone()))
+        .unwrap_or_else(|| soroban_sdk::Vec::new(env))
+}
+
+pub fn set_event_disputes(env: &Env, event_id: &Symbol, disputes: &soroban_sdk::Vec<u64>) {
+    let key = DataKey::EventDisputes(event_id.clone());
+    env.storage().persistent().set(&key, disputes);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, TTL_THRESHOLD, TTL_BUMP);
 }

--- a/contracts/payments/src/storage.rs
+++ b/contracts/payments/src/storage.rs
@@ -823,9 +823,7 @@ pub fn remove_resale_listing(env: &Env, ticket_id: u64) {
 }
 
 pub fn get_dispute(env: &Env, ticket_id: u64) -> Option<crate::types::DisputeRecord> {
-    env.storage()
-        .persistent()
-        .get(&DataKey::Dispute(ticket_id))
+    env.storage().persistent().get(&DataKey::Dispute(ticket_id))
 }
 
 pub fn set_dispute(env: &Env, ticket_id: u64, record: &crate::types::DisputeRecord) {
@@ -837,7 +835,9 @@ pub fn set_dispute(env: &Env, ticket_id: u64, record: &crate::types::DisputeReco
 }
 
 pub fn remove_dispute(env: &Env, ticket_id: u64) {
-    env.storage().persistent().remove(&DataKey::Dispute(ticket_id));
+    env.storage()
+        .persistent()
+        .remove(&DataKey::Dispute(ticket_id));
 }
 
 pub fn get_event_disputes(env: &Env, event_id: &Symbol) -> soroban_sdk::Vec<u64> {

--- a/contracts/payments/src/test_disputes.rs
+++ b/contracts/payments/src/test_disputes.rs
@@ -106,12 +106,12 @@ fn test_raise_dispute_success_and_window_rules() {
     let ticket_id = 1u64;
 
     // Before event_end_ledger should fail
-    let res = client.try_raise_dispute(&ticket_id, &0);
+    let res = client.try_raise_dispute(&ticket_id, &0, &None);
     assert_eq!(res, Err(Ok(PaymentError::DisputeWindowClosed)));
 
     // At event_end_ledger should succeed
     env.ledger().with_mut(|l| l.sequence_number = end_ledger);
-    client.raise_dispute(&ticket_id, &0);
+    client.raise_dispute(&ticket_id, &0, &None);
 
     let ticket = client.get_ticket(&ticket_id);
     let payment = client.get_payment(&ticket.payment_id);
@@ -121,7 +121,7 @@ fn test_raise_dispute_success_and_window_rules() {
     assert_eq!(client.get_event_revenue(&event_id), 0);
 
     // Raising dispute again on same ticket should fail
-    let res = client.try_raise_dispute(&ticket_id, &0);
+    let res = client.try_raise_dispute(&ticket_id, &0, &None);
     assert_eq!(res, Err(Ok(PaymentError::DisputeAlreadyExists)));
 }
 
@@ -162,7 +162,7 @@ fn test_dispute_window_expiration() {
     // 7 days in ledgers = 17280 * 7 = 120960. At end_ledger + 120960 window is closed.
     env.ledger()
         .with_mut(|l| l.sequence_number = end_ledger + 120_960);
-    let res = client.try_raise_dispute(&ticket_id, &1);
+    let res = client.try_raise_dispute(&ticket_id, &1, &None);
     assert_eq!(res, Err(Ok(PaymentError::DisputeWindowClosed)));
 }
 
@@ -200,7 +200,7 @@ fn test_invalid_dispute_reason_code() {
         &None,
     );
 
-    let res = client.try_raise_dispute(&1u64, &3);
+    let res = client.try_raise_dispute(&1u64, &3, &None);
     assert_eq!(res, Err(Ok(PaymentError::InvalidDisputeReason)));
 }
 
@@ -239,7 +239,7 @@ fn test_admin_approve_refund() {
     let ticket_id = 1u64;
 
     env.ledger().with_mut(|l| l.sequence_number = end_ledger);
-    client.raise_dispute(&ticket_id, &2);
+    client.raise_dispute(&ticket_id, &2, &None);
 
     let tc = token::Client::new(&env, &token);
     let balance_before = tc.balance(&payer);
@@ -286,7 +286,7 @@ fn test_admin_reject_dispute() {
     let ticket_id = 1u64;
 
     env.ledger().with_mut(|l| l.sequence_number = end_ledger);
-    client.raise_dispute(&ticket_id, &1);
+    client.raise_dispute(&ticket_id, &1, &None);
 
     assert_eq!(client.get_event_revenue(&event_id), 0);
 
@@ -332,7 +332,7 @@ fn test_dispute_14_day_timeout_auto_releases_to_organizer() {
     let ticket_id = 1u64;
 
     env.ledger().with_mut(|l| l.sequence_number = end_ledger);
-    client.raise_dispute(&ticket_id, &0);
+    client.raise_dispute(&ticket_id, &0, &None);
     assert_eq!(client.get_event_revenue(&event_id), 0);
 
     // Advance 14 days in ledgers (17280 * 14 = 241920)
@@ -367,7 +367,8 @@ fn test_anonymous_ticket_dispute() {
     );
     fund(&env, &admin, &payer, &token, 2000);
 
-    let commitment = BytesN::from_array(&env, &[7u8; 32]);
+    let preimage = soroban_sdk::Bytes::from_slice(&env, &[1u8; 32]);
+    let commitment: BytesN<32> = env.crypto().sha256(&preimage).into();
     client.pay_for_ticket(
         &1,
         &payer,
@@ -383,7 +384,7 @@ fn test_anonymous_ticket_dispute() {
 
     env.ledger().with_mut(|l| l.sequence_number = end_ledger);
     // Raise dispute on anonymous ticket via ticket_id only
-    client.raise_dispute(&ticket_id, &2);
+    client.raise_dispute(&ticket_id, &2, &Some(preimage));
 
     let payment = client.get_payment(&1u64);
     assert_eq!(payment.status, PaymentStatus::Disputed);

--- a/contracts/payments/src/test_disputes.rs
+++ b/contracts/payments/src/test_disputes.rs
@@ -26,7 +26,14 @@ fn setup(
     client.initialize(&admin, &token, &0, &platform_wallet, &event_contract_id);
 
     let token_client = token::StellarAssetClient::new(env, &token);
-    (admin, token, client, contract_id, token_client, event_contract_id)
+    (
+        admin,
+        token,
+        client,
+        contract_id,
+        token_client,
+        event_contract_id,
+    )
 }
 
 fn fund(env: &Env, admin: &Address, payer: &Address, token: &Address, amount: i128) {
@@ -73,7 +80,15 @@ fn test_raise_dispute_success_and_window_rules() {
     let event_id = symbol_short!("EV");
     let end_ledger = 1000u32;
 
-    bind_event(&client, &event_contract, &event_id, &organizer, &token, false, end_ledger);
+    bind_event(
+        &client,
+        &event_contract,
+        &event_id,
+        &organizer,
+        &token,
+        false,
+        end_ledger,
+    );
     fund(&env, &admin, &payer, &token, 2000);
 
     env.ledger().with_mut(|l| l.sequence_number = 500);
@@ -120,7 +135,15 @@ fn test_dispute_window_expiration() {
     let event_id = symbol_short!("EV");
     let end_ledger = 1000u32;
 
-    bind_event(&client, &event_contract, &event_id, &organizer, &token, false, end_ledger);
+    bind_event(
+        &client,
+        &event_contract,
+        &event_id,
+        &organizer,
+        &token,
+        false,
+        end_ledger,
+    );
     fund(&env, &admin, &payer, &token, 2000);
 
     client.pay_for_ticket(
@@ -137,7 +160,8 @@ fn test_dispute_window_expiration() {
     let ticket_id = 1u64;
 
     // 7 days in ledgers = 17280 * 7 = 120960. At end_ledger + 120960 window is closed.
-    env.ledger().with_mut(|l| l.sequence_number = end_ledger + 120_960);
+    env.ledger()
+        .with_mut(|l| l.sequence_number = end_ledger + 120_960);
     let res = client.try_raise_dispute(&ticket_id, &1);
     assert_eq!(res, Err(Ok(PaymentError::DisputeWindowClosed)));
 }
@@ -152,7 +176,15 @@ fn test_invalid_dispute_reason_code() {
     let event_id = symbol_short!("EV");
     let end_ledger = 1000u32;
 
-    bind_event(&client, &event_contract, &event_id, &organizer, &token, false, end_ledger);
+    bind_event(
+        &client,
+        &event_contract,
+        &event_id,
+        &organizer,
+        &token,
+        false,
+        end_ledger,
+    );
     fund(&env, &admin, &payer, &token, 2000);
 
     env.ledger().with_mut(|l| l.sequence_number = end_ledger);
@@ -182,7 +214,15 @@ fn test_admin_approve_refund() {
     let event_id = symbol_short!("EV");
     let end_ledger = 1000u32;
 
-    bind_event(&client, &event_contract, &event_id, &organizer, &token, false, end_ledger);
+    bind_event(
+        &client,
+        &event_contract,
+        &event_id,
+        &organizer,
+        &token,
+        false,
+        end_ledger,
+    );
     fund(&env, &admin, &payer, &token, 2000);
 
     client.pay_for_ticket(
@@ -221,7 +261,15 @@ fn test_admin_reject_dispute() {
     let event_id = symbol_short!("EV");
     let end_ledger = 1000u32;
 
-    bind_event(&client, &event_contract, &event_id, &organizer, &token, false, end_ledger);
+    bind_event(
+        &client,
+        &event_contract,
+        &event_id,
+        &organizer,
+        &token,
+        false,
+        end_ledger,
+    );
     fund(&env, &admin, &payer, &token, 2000);
 
     client.pay_for_ticket(
@@ -259,7 +307,15 @@ fn test_dispute_14_day_timeout_auto_releases_to_organizer() {
     let event_id = symbol_short!("EV");
     let end_ledger = 1000u32;
 
-    bind_event(&client, &event_contract, &event_id, &organizer, &token, false, end_ledger);
+    bind_event(
+        &client,
+        &event_contract,
+        &event_id,
+        &organizer,
+        &token,
+        false,
+        end_ledger,
+    );
     fund(&env, &admin, &payer, &token, 2000);
 
     client.pay_for_ticket(
@@ -280,7 +336,8 @@ fn test_dispute_14_day_timeout_auto_releases_to_organizer() {
     assert_eq!(client.get_event_revenue(&event_id), 0);
 
     // Advance 14 days in ledgers (17280 * 14 = 241920)
-    env.ledger().with_mut(|l| l.sequence_number = end_ledger + 241_920);
+    env.ledger()
+        .with_mut(|l| l.sequence_number = end_ledger + 241_920);
 
     client.process_dispute_timeouts(&event_id);
 
@@ -299,7 +356,15 @@ fn test_anonymous_ticket_dispute() {
     let event_id = symbol_short!("EV");
     let end_ledger = 1000u32;
 
-    bind_event(&client, &event_contract, &event_id, &organizer, &token, true, end_ledger);
+    bind_event(
+        &client,
+        &event_contract,
+        &event_id,
+        &organizer,
+        &token,
+        true,
+        end_ledger,
+    );
     fund(&env, &admin, &payer, &token, 2000);
 
     let commitment = BytesN::from_array(&env, &[7u8; 32]);

--- a/contracts/payments/src/test_disputes.rs
+++ b/contracts/payments/src/test_disputes.rs
@@ -1,0 +1,325 @@
+//! Tests for attendee-initiated dispute resolution and refund hooks (Issue #113/attendee path).
+
+use super::*;
+use mock_event_contract::MockEventContract;
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::{symbol_short, token, Address, BytesN, Env, Symbol};
+
+fn setup(
+    env: &Env,
+) -> (
+    Address,
+    Address,
+    PaymentsContractClient<'_>,
+    Address,
+    token::StellarAssetClient<'_>,
+    Address,
+) {
+    let contract_id = env.register(PaymentsContract, ());
+    let client = PaymentsContractClient::new(env, &contract_id);
+    let event_contract_id = env.register(MockEventContract, ());
+
+    let admin = Address::generate(env);
+    let platform_wallet = Address::generate(env);
+    let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+    let token = token_contract.address();
+    client.initialize(&admin, &token, &0, &platform_wallet, &event_contract_id);
+
+    let token_client = token::StellarAssetClient::new(env, &token);
+    (admin, token, client, contract_id, token_client, event_contract_id)
+}
+
+fn fund(env: &Env, admin: &Address, payer: &Address, token: &Address, amount: i128) {
+    let sac = token::StellarAssetClient::new(env, token);
+    sac.mint(admin, &amount);
+    let tc = token::Client::new(env, token);
+    tc.transfer(admin, payer, &amount);
+}
+
+fn bind_event(
+    client: &PaymentsContractClient,
+    event_contract: &Address,
+    event_id: &Symbol,
+    organizer: &Address,
+    payout_token: &Address,
+    allow_anonymous: bool,
+    end_ledger: u32,
+) {
+    client.sync_event_config(
+        event_contract,
+        event_id,
+        organizer,
+        payout_token,
+        &allow_anonymous,
+        &false,
+        &1000,
+        &0,
+        &0,
+        &end_ledger,
+        &17280,
+        &0,
+        &None,
+        &false,
+    );
+}
+
+#[test]
+fn test_raise_dispute_success_and_window_rules() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc, event_contract) = setup(&env);
+    let organizer = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let end_ledger = 1000u32;
+
+    bind_event(&client, &event_contract, &event_id, &organizer, &token, false, end_ledger);
+    fund(&env, &admin, &payer, &token, 2000);
+
+    env.ledger().with_mut(|l| l.sequence_number = 500);
+    client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &1000,
+        &None,
+        &token,
+        &PaymentPrivacy::Standard,
+        &None,
+        &None,
+    );
+    let ticket_id = 1u64;
+
+    // Before event_end_ledger should fail
+    let res = client.try_raise_dispute(&ticket_id, &0);
+    assert_eq!(res, Err(Ok(PaymentError::DisputeWindowClosed)));
+
+    // At event_end_ledger should succeed
+    env.ledger().with_mut(|l| l.sequence_number = end_ledger);
+    client.raise_dispute(&ticket_id, &0);
+
+    let ticket = client.get_ticket(&ticket_id);
+    let payment = client.get_payment(&ticket.payment_id);
+    assert_eq!(payment.status, PaymentStatus::Disputed);
+
+    // Revenue should be reduced while disputed
+    assert_eq!(client.get_event_revenue(&event_id), 0);
+
+    // Raising dispute again on same ticket should fail
+    let res = client.try_raise_dispute(&ticket_id, &0);
+    assert_eq!(res, Err(Ok(PaymentError::DisputeAlreadyExists)));
+}
+
+#[test]
+fn test_dispute_window_expiration() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc, event_contract) = setup(&env);
+    let organizer = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let end_ledger = 1000u32;
+
+    bind_event(&client, &event_contract, &event_id, &organizer, &token, false, end_ledger);
+    fund(&env, &admin, &payer, &token, 2000);
+
+    client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &1000,
+        &None,
+        &token,
+        &PaymentPrivacy::Standard,
+        &None,
+        &None,
+    );
+    let ticket_id = 1u64;
+
+    // 7 days in ledgers = 17280 * 7 = 120960. At end_ledger + 120960 window is closed.
+    env.ledger().with_mut(|l| l.sequence_number = end_ledger + 120_960);
+    let res = client.try_raise_dispute(&ticket_id, &1);
+    assert_eq!(res, Err(Ok(PaymentError::DisputeWindowClosed)));
+}
+
+#[test]
+fn test_invalid_dispute_reason_code() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc, event_contract) = setup(&env);
+    let organizer = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let end_ledger = 1000u32;
+
+    bind_event(&client, &event_contract, &event_id, &organizer, &token, false, end_ledger);
+    fund(&env, &admin, &payer, &token, 2000);
+
+    env.ledger().with_mut(|l| l.sequence_number = end_ledger);
+    client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &1000,
+        &None,
+        &token,
+        &PaymentPrivacy::Standard,
+        &None,
+        &None,
+    );
+
+    let res = client.try_raise_dispute(&1u64, &3);
+    assert_eq!(res, Err(Ok(PaymentError::InvalidDisputeReason)));
+}
+
+#[test]
+fn test_admin_approve_refund() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc, event_contract) = setup(&env);
+    let organizer = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let end_ledger = 1000u32;
+
+    bind_event(&client, &event_contract, &event_id, &organizer, &token, false, end_ledger);
+    fund(&env, &admin, &payer, &token, 2000);
+
+    client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &1000,
+        &None,
+        &token,
+        &PaymentPrivacy::Standard,
+        &None,
+        &None,
+    );
+    let ticket_id = 1u64;
+
+    env.ledger().with_mut(|l| l.sequence_number = end_ledger);
+    client.raise_dispute(&ticket_id, &2);
+
+    let tc = token::Client::new(&env, &token);
+    let balance_before = tc.balance(&payer);
+
+    client.approve_refund(&ticket_id);
+
+    let payment = client.get_payment(&1u64);
+    assert_eq!(payment.status, PaymentStatus::Refunded);
+    assert_eq!(tc.balance(&payer), balance_before + 1000);
+}
+
+#[test]
+fn test_admin_reject_dispute() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc, event_contract) = setup(&env);
+    let organizer = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let end_ledger = 1000u32;
+
+    bind_event(&client, &event_contract, &event_id, &organizer, &token, false, end_ledger);
+    fund(&env, &admin, &payer, &token, 2000);
+
+    client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &1000,
+        &None,
+        &token,
+        &PaymentPrivacy::Standard,
+        &None,
+        &None,
+    );
+    let ticket_id = 1u64;
+
+    env.ledger().with_mut(|l| l.sequence_number = end_ledger);
+    client.raise_dispute(&ticket_id, &1);
+
+    assert_eq!(client.get_event_revenue(&event_id), 0);
+
+    client.reject_dispute(&ticket_id);
+
+    let payment = client.get_payment(&1u64);
+    assert_eq!(payment.status, PaymentStatus::Held);
+    assert_eq!(client.get_event_revenue(&event_id), 1000);
+}
+
+#[test]
+fn test_dispute_14_day_timeout_auto_releases_to_organizer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc, event_contract) = setup(&env);
+    let organizer = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let end_ledger = 1000u32;
+
+    bind_event(&client, &event_contract, &event_id, &organizer, &token, false, end_ledger);
+    fund(&env, &admin, &payer, &token, 2000);
+
+    client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &1000,
+        &None,
+        &token,
+        &PaymentPrivacy::Standard,
+        &None,
+        &None,
+    );
+    let ticket_id = 1u64;
+
+    env.ledger().with_mut(|l| l.sequence_number = end_ledger);
+    client.raise_dispute(&ticket_id, &0);
+    assert_eq!(client.get_event_revenue(&event_id), 0);
+
+    // Advance 14 days in ledgers (17280 * 14 = 241920)
+    env.ledger().with_mut(|l| l.sequence_number = end_ledger + 241_920);
+
+    client.process_dispute_timeouts(&event_id);
+
+    let payment = client.get_payment(&1u64);
+    assert_eq!(payment.status, PaymentStatus::Held);
+    assert_eq!(client.get_event_revenue(&event_id), 1000);
+}
+
+#[test]
+fn test_anonymous_ticket_dispute() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, _tc, event_contract) = setup(&env);
+    let organizer = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let event_id = symbol_short!("EV");
+    let end_ledger = 1000u32;
+
+    bind_event(&client, &event_contract, &event_id, &organizer, &token, true, end_ledger);
+    fund(&env, &admin, &payer, &token, 2000);
+
+    let commitment = BytesN::from_array(&env, &[7u8; 32]);
+    client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &1000,
+        &None,
+        &token,
+        &PaymentPrivacy::Anonymous,
+        &Some(commitment),
+        &None,
+    );
+    let ticket_id = 1u64;
+
+    env.ledger().with_mut(|l| l.sequence_number = end_ledger);
+    // Raise dispute on anonymous ticket via ticket_id only
+    client.raise_dispute(&ticket_id, &2);
+
+    let payment = client.get_payment(&1u64);
+    assert_eq!(payment.status, PaymentStatus::Disputed);
+}

--- a/contracts/payments/src/types.rs
+++ b/contracts/payments/src/types.rs
@@ -17,6 +17,7 @@ pub enum PaymentStatus {
     Held = 0,
     Released = 1,
     Refunded = 2,
+    Disputed = 3,
 }
 
 #[contracttype]
@@ -114,3 +115,14 @@ pub struct ResaleListing {
     pub price: i128,
     pub seller: Address,
 }
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DisputeRecord {
+    pub ticket_id: u64,
+    pub event_id: Symbol,
+    pub payment_id: u64,
+    pub reason_code: u32,
+    pub raised_at_ledger: u32,
+}
+

--- a/contracts/payments/src/types.rs
+++ b/contracts/payments/src/types.rs
@@ -125,4 +125,3 @@ pub struct DisputeRecord {
     pub reason_code: u32,
     pub raised_at_ledger: u32,
 }
-


### PR DESCRIPTION
This PR addresses a critical gap in #113 (Dispute Resolution Hooks) by implementing a complete attendee-initiated dispute and refund workflow. Previously, dispute paths only served organizers and platform admins. This implementation introduces full attendee recourse for event misrepresentation, non-delivery, or cancellations while maintaining zero-knowledge/privacy guarantees for anonymous ticket holders.

## Key Changes & Features

### 1. Attendee Recourse (`raise_dispute`)

- Attendees can call `raise_dispute(ticket_id, reason_code)` once `event_end_ledger` is reached.
- **Reason Codes Supported:**
  - `0` = `event_no_show`
  - `1` = `ticket_not_delivered`
  - `2` = `description_mismatch`
- **Window Enforcement:** Disputes can only be raised within a 7-day window ($17{,}280 \times 7$ ledgers) post-event. Any attempts outside this window fail with `DisputeWindowClosed`.

### 2. Anonymous Ticket Support

- Tickets purchased under `PaymentPrivacy::Anonymous` can initiate disputes using only their `ticket_id`.
- No wallet authentication linkage or identity disclosure is required to raise a dispute, preserving on-chain privacy semantics.

### 3. Platform Admin Resolution Hooks

- `approve_refund(ticket_id)`: Admin hook that approves an attendee's refund request, transfers the escrowed tokens back to the ticket payer, transitions status to `Refunded`, and clears the dispute record.
- `reject_dispute(ticket_id)`: Admin hook that rejects an invalid dispute, restores the payment status to `Held`, re-credits the event revenue pool, and clears the dispute record.

### 4. Organizer-Favoured Timeout (14-Day Auto-Release)

- If a dispute remains unresolved by platform admins for 14 days ($17{,}280 \times 14$ ledgers), the disputed share auto-releases in favor of the organizer.
- Integrated automated timeout processing (`process_timed_out_disputes`) directly into the contract's accounting invariants, guaranteeing that timed-out disputes are automatically restored to the organizer's withdrawable pool before any withdrawal or revenue check occurs.

closes #125 

# Screenshot
<img width="837" height="891" alt="Screenshot 2026-07-27 200924" src="https://github.com/user-attachments/assets/a2049257-9a31-44db-9a1e-2130b1616a94" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added attendee dispute flow with new `Disputed` payment status and dispute tracking (including for eligible anonymous tickets).
  * Added administrator actions to approve refunds or reject disputes, plus public dispute-timeout processing.
  * Added contract events for dispute raised/resolved/timed out.
  * Updated settlement and withdrawals to block when disputes are active and to automatically handle expired disputes.
* **Tests**
  * Added integration coverage for dispute timing rules, duplicate prevention, invalid reasons, refund approval, rejection, timeout handling, and anonymous-ticket disputes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->