### PR TITLE
Expand test coverage for escrow splits, postponement, and resale edge cases

### DIFF
--- a/contracts/event/src/integration_tests.rs
+++ b/contracts/event/src/integration_tests.rs
@@ -975,3 +975,214 @@ fn test_event_flag_cohost_through_front_door() {
     // Co-host's share remains escrowed.
     assert_eq!(w.token_client.balance(&w.payments_contract_id), 40_000_000);
 }
+
+// ── #145: postponement choice-deadline boundary & resale royalty edge case ──
+
+#[test]
+fn test_postponement_refund_exactly_at_choice_deadline_ledger_still_succeeds() {
+    let env = setup_env();
+    env.ledger().with_mut(|li| li.sequence_number = 100);
+
+    let (
+        event_client,
+        payments_client,
+        _ticket_client,
+        token_client,
+        token_admin_client,
+        token_address,
+        organizer,
+        payments_id,
+    ) = setup_linked(&env);
+
+    let attendee = Address::generate(&env);
+    fund(&token_admin_client, &attendee, PRICE);
+
+    let event_id = Symbol::new(&env, "evt_pp_boundary");
+    create_active_event(
+        &env,
+        &event_client,
+        &organizer,
+        &token_address,
+        event_id.clone(),
+    );
+    event_client.register_for_event(&1, &attendee, &event_id, &0, &false, &None);
+
+    let new_date = 100 + MIN_WINDOW as u64 + 10_000;
+    event_client.postpone_event(&organizer, &event_id, &new_date, &MIN_WINDOW);
+    // choice_deadline_ledger = 100 + MIN_WINDOW.
+
+    let t = payments_client.get_owner_tickets(&attendee).get(0).unwrap();
+
+    // At exactly the deadline ledger the choice window is still open (`<=`).
+    env.ledger()
+        .with_mut(|li| li.sequence_number = 100 + MIN_WINDOW);
+    event_client.request_postponement_refund(&attendee, &t);
+
+    assert_eq!(token_client.balance(&attendee), PRICE);
+    assert_eq!(token_client.balance(&payments_id), 0);
+    assert!(!event_client.is_registered(&event_id, &attendee));
+}
+
+#[test]
+fn test_postponement_refund_one_ledger_past_deadline_fails() {
+    let env = setup_env();
+    env.ledger().with_mut(|li| li.sequence_number = 100);
+
+    let (
+        event_client,
+        payments_client,
+        _ticket_client,
+        _token_client,
+        token_admin_client,
+        token_address,
+        organizer,
+        _payments_id,
+    ) = setup_linked(&env);
+
+    let attendee = Address::generate(&env);
+    fund(&token_admin_client, &attendee, PRICE);
+
+    let event_id = Symbol::new(&env, "evt_pp_boundary2");
+    create_active_event(
+        &env,
+        &event_client,
+        &organizer,
+        &token_address,
+        event_id.clone(),
+    );
+    event_client.register_for_event(&1, &attendee, &event_id, &0, &false, &None);
+
+    let new_date = 100 + MIN_WINDOW as u64 + 10_000;
+    event_client.postpone_event(&organizer, &event_id, &new_date, &MIN_WINDOW);
+
+    let t = payments_client.get_owner_tickets(&attendee).get(0).unwrap();
+
+    // One ledger past the deadline the window is closed.
+    env.ledger()
+        .with_mut(|li| li.sequence_number = 100 + MIN_WINDOW + 1);
+    let res = payments_client.try_request_postponement_refund(&attendee, &t);
+    assert_eq!(
+        res.err(),
+        Some(Ok(
+            payments_contract::PaymentError::PostponementWindowClosed
+        ))
+    );
+}
+
+#[test]
+fn test_resale_royalty_exceeding_proceeds_leaves_seller_unpaid() {
+    let env = setup_env();
+
+    let organizer = Address::generate(&env);
+    let attendee = Address::generate(&env);
+    let buyer = Address::generate(&env);
+
+    let event_contract_id = env.register(EventContract, ());
+    let event_client = EventContractClient::new(&env, &event_contract_id);
+    let ticket_contract_id = env.register(ticket_contract::TicketContract, ());
+    let ticket_client = ticket_contract::TicketContractClient::new(&env, &ticket_contract_id);
+    let payments_contract_id = env.register(payments_contract::PaymentsContract, ());
+    let payments_client =
+        payments_contract::PaymentsContractClient::new(&env, &payments_contract_id);
+
+    let token_admin = Address::generate(&env);
+    let token_address = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_address);
+    let token_client = token::Client::new(&env, &token_address);
+
+    let platform_wallet = Address::generate(&env);
+    payments_client.initialize(
+        &organizer,
+        &token_address,
+        &0,
+        &platform_wallet,
+        &event_contract_id,
+    );
+    event_client.initialize(&organizer, &ticket_contract_id, &payments_contract_id);
+    ticket_client.set_payments_contract(&organizer, &payments_contract_id);
+    payments_client.set_ticket_contract(&organizer, &ticket_contract_id);
+
+    let event_id = Symbol::new(&env, "evt_resale_royalty");
+    let params = CreateEventParams {
+        organizer: organizer.clone(),
+        payout_token: token_address.clone(),
+        event_id: event_id.clone(),
+        name: String::from_str(&env, "Resale Royalty Event"),
+        description: String::from_str(&env, "Edge case"),
+        venue: String::from_str(&env, "Main Hall"),
+        event_date: env.ledger().timestamp() + 86_401,
+        initial_tiers: soroban_sdk::vec![
+            &env,
+            TicketTierParams {
+                name: String::from_str(&env, "General"),
+                price: 100_000_000,
+                capacity: 10,
+            },
+        ],
+        allow_anonymous: true,
+        requires_verification: false,
+        privacy_level: PrivacyLevel::Standard,
+        max_tickets_per_user: 0,
+        event_start_ledger: 0,
+        event_end_ledger: 1000,
+        withdrawal_delay_ledgers: 17280,
+        revenue_splits: soroban_sdk::Vec::new(&env),
+        resale_royalty_bps: 0,
+        max_resale_price: None,
+        allow_free_ticket_transfer: false,
+    };
+    event_client.create_event(&params);
+    event_client.update_event_status(&organizer, &event_id, &EventStatus::Active);
+
+    let price = 100_000_000i128;
+    token_admin_client.mint(&attendee, &price);
+    event_client.register_for_event(&1, &attendee, &event_id, &0, &false, &None);
+
+    // The event contract's front door caps resale_royalty_bps at 2000 (20%),
+    // but `sync_event_config` on the payments contract itself has no such
+    // guard. A misconfigured or malicious sync can push the royalty above
+    // 10_000 bps, i.e. above the resale price itself.
+    payments_client.sync_event_config(
+        &event_contract_id,
+        &event_id,
+        &organizer,
+        &token_address,
+        &true,
+        &false,
+        &0,
+        &0,
+        &0,
+        &1000,
+        &17280,
+        &15_000, // 150% royalty: exceeds total resale proceeds.
+        &None,
+        &false,
+    );
+
+    let owner_tickets = payments_client.get_owner_tickets(&attendee);
+    let ticket_id = owner_tickets.get(0).unwrap();
+
+    let resale_price = 50_000_000i128;
+    payments_client.list_ticket_for_resale(&attendee, &ticket_id, &resale_price);
+
+    token_admin_client.mint(&buyer, &resale_price);
+    payments_client.buy_resale_ticket(&buyer, &ticket_id);
+
+    // royalty = 50_000_000 * 15_000 / 10_000 = 75_000_000, which alone exceeds
+    // the 50_000_000 the buyer paid. seller_proceeds computes negative and the
+    // `> 0` guard means the seller is paid nothing at all, while the buyer's
+    // full resale payment is now held by the contract alongside the original
+    // ticket price (100_000_000) still escrowed from registration.
+    assert_eq!(token_client.balance(&attendee), 0);
+    assert_eq!(token_client.balance(&buyer), 0);
+    assert_eq!(
+        token_client.balance(&payments_contract_id),
+        price + resale_price
+    );
+
+    // Ownership still transfers even though the seller received no proceeds.
+    let ticket = payments_client.get_ticket(&ticket_id);
+    assert_eq!(ticket.owner, Some(buyer));
+}

--- a/contracts/payments/src/revenue_split_test.rs
+++ b/contracts/payments/src/revenue_split_test.rs
@@ -623,3 +623,180 @@ fn test_cancelled_split_settlement_survives_attendee_refund() {
     assert_eq!(tc.balance(&organizer), 60_000_000);
     assert_eq!(tc.balance(&contract_id), 0);
 }
+
+// ── #145: multi-token settlements, mid-event flagging, delay extensions ──────
+
+#[test]
+fn test_cohost_flagged_mid_event_before_completion_blocks_withdrawal_after_settlement() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, event_contract) = make_payments(&env, 0);
+    let organizer = Address::generate(&env);
+    let cohost = Address::generate(&env);
+    let event_id = symbol_short!("MIDFLAG");
+    bind(&client, &event_contract, &event_id, &organizer, &token);
+
+    let splits: Vec<(Address, u32)> = vec![
+        &env,
+        (organizer.clone(), 6000u32),
+        (cohost.clone(), 4000u32),
+    ];
+    client.sync_revenue_splits(&event_contract, &event_id, &splits);
+
+    let payer = Address::generate(&env);
+    token::StellarAssetClient::new(&env, &token).mint(&payer, &100_000_000);
+    client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &100_000_000,
+        &None,
+        &token,
+        &PaymentPrivacy::Standard,
+        &None,
+        &None,
+    );
+
+    // Event is still active (not yet completed) when the primary flags the co-host.
+    client.flag_cohost(&organizer, &event_id, &cohost);
+    assert!(client.is_recipient_flagged(&event_id, &cohost));
+
+    // Completion and settlement happen afterwards.
+    client.set_event_status(&admin, &event_id, &EventStatus::Completed);
+    env.ledger().with_mut(|li| li.sequence_number = 20_000);
+
+    // The flag set before settlement still blocks withdrawal once settled.
+    assert_eq!(
+        client.try_withdraw_split(&cohost, &event_id).err(),
+        Some(Ok(PaymentError::RecipientFlagged))
+    );
+    client.withdraw_split(&organizer, &event_id);
+    assert_eq!(
+        token::Client::new(&env, &token).balance(&organizer),
+        60_000_000
+    );
+}
+
+#[test]
+fn test_revenue_split_settlement_ignores_non_payout_token_revenue() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, contract_id, event_contract) = make_payments(&env, 0);
+    let organizer = Address::generate(&env);
+    let cohost = Address::generate(&env);
+    let event_id = symbol_short!("MULTITOK");
+    bind(&client, &event_contract, &event_id, &organizer, &token);
+
+    let splits: Vec<(Address, u32)> = vec![
+        &env,
+        (organizer.clone(), 6000u32),
+        (cohost.clone(), 4000u32),
+    ];
+    client.sync_revenue_splits(&event_contract, &event_id, &splits);
+
+    // Payout-token revenue that participates in the split.
+    let payer = Address::generate(&env);
+    token::StellarAssetClient::new(&env, &token).mint(&payer, &100_000_000);
+    client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &100_000_000,
+        &None,
+        &token,
+        &PaymentPrivacy::Standard,
+        &None,
+        &None,
+    );
+
+    // A second token used for the same event (e.g. a stray/legacy payment in a
+    // different currency). It must not inflate or shrink the split payout.
+    let admin2 = Address::generate(&env);
+    let other_token_contract = env.register_stellar_asset_contract_v2(admin2.clone());
+    let other_token = other_token_contract.address();
+    let payer2 = Address::generate(&env);
+    token::StellarAssetClient::new(&env, &other_token).mint(&payer2, &500_000_000);
+    client.pay_for_ticket(
+        &2,
+        &payer2,
+        &event_id,
+        &500_000_000,
+        &None,
+        &other_token,
+        &PaymentPrivacy::Standard,
+        &None,
+        &None,
+    );
+
+    client.flag_cohost(&organizer, &event_id, &cohost);
+    client.set_event_status(&admin, &event_id, &EventStatus::Completed);
+    env.ledger().with_mut(|li| li.sequence_number = 20_000);
+
+    client.resolve_flagged_share(&event_id, &cohost, &FlagResolution::ReleaseToRecipient);
+    client.withdraw_split(&cohost, &event_id);
+    client.withdraw_split(&organizer, &event_id);
+
+    let tc = token::Client::new(&env, &token);
+    assert_eq!(tc.balance(&cohost), 40_000_000);
+    assert_eq!(tc.balance(&organizer), 60_000_000);
+    assert_eq!(tc.balance(&contract_id), 0);
+
+    // The other token's revenue is untouched by the split settlement.
+    assert_eq!(client.get_event_token_revenue(&event_id, &other_token), 500_000_000);
+    let other_tc = token::Client::new(&env, &other_token);
+    assert_eq!(other_tc.balance(&contract_id), 500_000_000);
+    assert_eq!(other_tc.balance(&cohost), 0);
+    assert_eq!(other_tc.balance(&organizer), 0);
+}
+
+#[test]
+fn test_withdraw_split_respects_admin_delay_extension_after_multiple_extensions() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, token, client, _cid, event_contract) = make_payments(&env, 0);
+    let organizer = Address::generate(&env);
+    let cohost = Address::generate(&env);
+    let event_id = symbol_short!("DELAYX");
+    bind(&client, &event_contract, &event_id, &organizer, &token);
+
+    let splits: Vec<(Address, u32)> = vec![
+        &env,
+        (organizer.clone(), 6000u32),
+        (cohost.clone(), 4000u32),
+    ];
+    client.sync_revenue_splits(&event_contract, &event_id, &splits);
+
+    let payer = Address::generate(&env);
+    token::StellarAssetClient::new(&env, &token).mint(&payer, &100_000_000);
+    client.pay_for_ticket(
+        &1,
+        &payer,
+        &event_id,
+        &100_000_000,
+        &None,
+        &token,
+        &PaymentPrivacy::Standard,
+        &None,
+        &None,
+    );
+    client.set_event_status(&admin, &event_id, &EventStatus::Completed);
+
+    // Base unlock is event_end_ledger(1000) + withdrawal_delay(17280) = 18280.
+    // Admin extends the delay twice (simulating repeated dispute holds).
+    client.extend_withdrawal_delay(&admin, &event_id, &5_000);
+    client.extend_withdrawal_delay(&admin, &event_id, &3_000);
+    // New unlock: 18280 + 5000 + 3000 = 26280.
+
+    env.ledger().with_mut(|li| li.sequence_number = 20_000);
+    assert_eq!(
+        client.try_withdraw_split(&cohost, &event_id).err(),
+        Some(Ok(PaymentError::EscrowNotExpired))
+    );
+
+    env.ledger().with_mut(|li| li.sequence_number = 26_281);
+    client.withdraw_split(&cohost, &event_id);
+    assert_eq!(
+        token::Client::new(&env, &token).balance(&cohost),
+        40_000_000
+    );
+}


### PR DESCRIPTION
Closes #145

## Summary
Adds automated test coverage for four high-risk edge cases identified in #145:

- **Multi-token revenue splits with mid-event co-host flagging** — flags a co-host before event completion/settlement and verifies the flag still blocks withdrawal after settlement; verifies split settlement only touches the event's payout-token revenue, leaving other-token revenue untouched.
- **Postponement refund boundary** — exercises `choice_deadline_ledger` exactly at the boundary (`<=` still open) and one ledger past it (closed).
- **Resale royalty exceeding proceeds** — `sync_event_config` on the payments contract has no cap on `resale_royalty_bps` (unlike the event contract's front door, which caps it at 2000 bps). This test documents current behavior when royalty bps alone exceeds the resale price: `seller_proceeds` goes negative, the `> 0` guard means the seller receives nothing, and the buyer's payment is fully retained by the contract while ownership still transfers.
- **Escrow release after multiple delay extensions** — verifies `extend_withdrawal_delay` calls are cumulative and correctly gate `withdraw_split`.

## Test plan
- [x] `cargo test -p payments-contract` — 21/21 passed
- [x] `cargo test -p event-contract` — 17/17 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming postponement refunds succeed at the exact deadline and fail immediately afterward.
  * Added coverage for resale royalties exceeding available proceeds, including ticket transfer and unpaid seller outcomes.
  * Added tests for co-host withdrawal restrictions, payout-token-only revenue splitting, and cumulative admin withdrawal delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->