### PR TITLE
fix: require claimant/owner auth for anonymous claims and ticket check-in

### DIFF
--- a/TICKET_CONSUMPTION_IMPLEMENTATION.md
+++ b/TICKET_CONSUMPTION_IMPLEMENTATION.md
@@ -16,12 +16,13 @@ This document describes the complete implementation of ticket consumption functi
 ### Core Function: `use_ticket`
 
 ```rust
-pub fn use_ticket(env: Env, organizer: Address, ticket_id: u64) -> Result<(), TicketError>
+pub fn use_ticket(env: Env, organizer: Address, owner: Address, ticket_id: u64) -> Result<(), TicketError>
 ```
 
 **Parameters:**
 - `env`: Soroban environment
 - `organizer`: Address of the event organizer (must be authorized)
+- `owner`: Address of the ticket holder presenting for check-in (must be authorized)
 - `ticket_id`: Unique identifier of the ticket to consume
 
 **Return:**
@@ -30,15 +31,23 @@ pub fn use_ticket(env: Env, organizer: Address, ticket_id: u64) -> Result<(), Ti
 ### Validation Logic
 
 1. **Organizer Authorization**: `organizer.require_auth()`
-   - Only the event organizer can call this function
-   
-2. **Ticket Existence**: Retrieves ticket from persistent storage
+   - The event organizer must co-sign the check-in
+
+2. **Owner Authorization**: `owner.require_auth()`
+   - The ticket holder must also authorize the check-in, so an organizer can
+     no longer unilaterally mark a ticket used without the holder's presence
+     or consent (see issue #144)
+
+3. **Ticket Existence**: Retrieves ticket from persistent storage
    - Returns `TicketNotFound` if ticket doesn't exist
    
-3. **Organizer Verification**: Verifies caller is the ticket's organizer
+4. **Organizer Verification**: Verifies caller is the ticket's organizer
    - Returns `Unauthorized` if caller is not the organizer
-   
-4. **Usage Validation**: Checks `is_used` field and status
+
+5. **Owner Verification**: Verifies `owner` matches the ticket's `owner`
+   - Returns `Unauthorized` if the presented owner does not match
+
+6. **Usage Validation**: Checks `is_used` field and status
    - Returns `TicketAlreadyUsed` if `is_used` is true
    - Returns `EventNotActive` if status is `Cancelled`
    - Returns `TicketAlreadyUsed` if status is `Used`
@@ -127,6 +136,11 @@ pub struct TicketUsed {
    - Non-organizer attempts to use ticket
    - Expects `Unauthorized` error
 
+3b. **Wrong Owner Rejected** (`test_use_ticket_wrong_owner_rejected`)
+   - Organizer attempts check-in against an address that is not the real
+     ticket owner
+   - Expects `Unauthorized` error, since the real owner never consented
+
 4. **Cancelled Ticket Usage** (`test_use_ticket_cancelled`)
    - Attempts to use cancelled ticket
    - Expects `EventNotActive` error
@@ -146,14 +160,20 @@ pub struct TicketUsed {
 - Initialized to `false` in `mint_ticket`
 - Set to `true` in `use_ticket`
 
-✅ **Entry function use_ticket(env, organizer, ticket_id)**
+✅ **Entry function use_ticket(env, organizer, owner, ticket_id)**
 - Function already implemented
 - Enhanced with `is_used` field validation
+- Enhanced with owner presentation/authorization (issue #144)
 - Maintains backward compatibility with `status` field
 
 ✅ **Validation: Only organizer can call**
 - Implemented via `organizer.require_auth()`
 - Additional organizer verification check
+
+✅ **Validation: Ticket owner must consent to check-in**
+- Implemented via `owner.require_auth()` plus a `ticket.owner == owner` check
+- An organizer alone can no longer force a check-in for a ticket they don't
+  hold; the holder must be present and sign the transaction too
 
 ✅ **Validation: Reject already used**
 - Implemented via `is_used` field check
@@ -179,10 +199,11 @@ pub struct TicketUsed {
 ## Usage Example
 
 ```rust
-// Organizer checks in a ticket
+// Organizer and ticket owner jointly check in a ticket
 let result = ticket_contract.use_ticket(
     &env,
     &organizer_address,
+    &owner_address,
     ticket_id
 );
 
@@ -206,6 +227,8 @@ match result {
 ## Security Considerations
 
 - Organizer authorization prevents unauthorized check-ins
+- Owner authorization prevents an organizer from unilaterally marking a
+  ticket used without the holder's presence or consent (issue #144)
 - `is_used` field validation prevents ticket reuse
 - Status validation provides additional protection
 - Immutable status transitions prevent fraud

--- a/contracts/event/src/lib.rs
+++ b/contracts/event/src/lib.rs
@@ -996,10 +996,16 @@ impl EventContract {
     }
     pub fn claim_anonymous_ticket(
         env: Env,
+        claimant: Address,
         event_id: Symbol,
         tier_id: u32,
         commitment: BytesN<32>,
     ) -> Result<(), EventError> {
+        // Require the claimant's signature so a third party who observes the
+        // commitment in the mempool cannot front-run or replay it: they can copy
+        // the (public) commitment bytes but cannot produce this signer's auth.
+        claimant.require_auth();
+
         let mut event = storage::get_event(&env, &event_id)?;
 
         if event.status != EventStatus::Active {

--- a/contracts/event/src/test_anon_claims.rs
+++ b/contracts/event/src/test_anon_claims.rs
@@ -142,11 +142,12 @@ fn test_anon_claim_basic_success() {
     let organizer = Address::generate(&env);
     let token = Address::generate(&env);
     let event_id = Symbol::new(&env, "anon_ok");
+    let claimant = Address::generate(&env);
 
     setup_contracts(&env, &client, &organizer, &token);
     create_anon_free_event(&env, &client, &organizer, &token, event_id.clone(), 10);
 
-    client.claim_anonymous_ticket(&event_id, &0, &commitment(&env, 1));
+    client.claim_anonymous_ticket(&claimant, &event_id, &0, &commitment(&env, 1));
 
     let event = client.get_event(&event_id);
     assert_eq!(event.sold_count, 1);
@@ -160,6 +161,7 @@ fn test_anon_claim_rejects_non_anonymous_event() {
     let organizer = Address::generate(&env);
     let token = Address::generate(&env);
     let event_id = Symbol::new(&env, "anon_dis");
+    let claimant = Address::generate(&env);
 
     setup_contracts(&env, &client, &organizer, &token);
 
@@ -194,7 +196,7 @@ fn test_anon_claim_rejects_non_anonymous_event() {
     client.create_event(&params);
     client.update_event_status(&organizer, &event_id, &EventStatus::Active);
 
-    let result = client.try_claim_anonymous_ticket(&event_id, &0, &commitment(&env, 1));
+    let result = client.try_claim_anonymous_ticket(&claimant, &event_id, &0, &commitment(&env, 1));
     assert_eq!(
         result.err(),
         Some(Ok(EventError::AnonymousClaimsNotEnabled))
@@ -209,6 +211,7 @@ fn test_anon_claim_paid_tier_fails() {
     let organizer = Address::generate(&env);
     let token = Address::generate(&env);
     let event_id = Symbol::new(&env, "anon_paid");
+    let claimant = Address::generate(&env);
 
     setup_contracts(&env, &client, &organizer, &token);
 
@@ -243,7 +246,7 @@ fn test_anon_claim_paid_tier_fails() {
     client.create_event(&params);
     client.update_event_status(&organizer, &event_id, &EventStatus::Active);
 
-    let result = client.try_claim_anonymous_ticket(&event_id, &0, &commitment(&env, 1));
+    let result = client.try_claim_anonymous_ticket(&claimant, &event_id, &0, &commitment(&env, 1));
     assert_eq!(result.err(), Some(Ok(EventError::InvalidInput)));
 }
 
@@ -255,15 +258,16 @@ fn test_anon_commitment_reused_fails() {
     let organizer = Address::generate(&env);
     let token = Address::generate(&env);
     let event_id = Symbol::new(&env, "anon_dup");
+    let claimant = Address::generate(&env);
 
     setup_contracts(&env, &client, &organizer, &token);
     create_anon_free_event(&env, &client, &organizer, &token, event_id.clone(), 50);
 
     let c = commitment(&env, 42);
 
-    client.claim_anonymous_ticket(&event_id, &0, &c);
+    client.claim_anonymous_ticket(&claimant, &event_id, &0, &c);
 
-    let result = client.try_claim_anonymous_ticket(&event_id, &0, &c);
+    let result = client.try_claim_anonymous_ticket(&claimant, &event_id, &0, &c);
     assert_eq!(result.err(), Some(Ok(EventError::AnonCommitmentReused)));
 }
 
@@ -275,12 +279,13 @@ fn test_distinct_commitments_each_accepted_once() {
     let organizer = Address::generate(&env);
     let token = Address::generate(&env);
     let event_id = Symbol::new(&env, "anon_dist");
+    let claimant = Address::generate(&env);
 
     setup_contracts(&env, &client, &organizer, &token);
     create_anon_free_event(&env, &client, &organizer, &token, event_id.clone(), 50);
 
     for i in 1u8..=5 {
-        client.claim_anonymous_ticket(&event_id, &0, &commitment(&env, i));
+        client.claim_anonymous_ticket(&claimant, &event_id, &0, &commitment(&env, i));
     }
 
     let event = client.get_event(&event_id);
@@ -295,15 +300,16 @@ fn test_anon_window_rate_limit_blocks_excess_claims() {
     let organizer = Address::generate(&env);
     let token = Address::generate(&env);
     let event_id = Symbol::new(&env, "anon_wlim");
+    let claimant = Address::generate(&env);
 
     setup_contracts(&env, &client, &organizer, &token);
     create_anon_free_event(&env, &client, &organizer, &token, event_id.clone(), 50);
     client.set_anon_claim_settings(&organizer, &event_id, &2, &100);
 
-    client.claim_anonymous_ticket(&event_id, &0, &commitment(&env, 1));
-    client.claim_anonymous_ticket(&event_id, &0, &commitment(&env, 2));
+    client.claim_anonymous_ticket(&claimant, &event_id, &0, &commitment(&env, 1));
+    client.claim_anonymous_ticket(&claimant, &event_id, &0, &commitment(&env, 2));
 
-    let result = client.try_claim_anonymous_ticket(&event_id, &0, &commitment(&env, 3));
+    let result = client.try_claim_anonymous_ticket(&claimant, &event_id, &0, &commitment(&env, 3));
     assert_eq!(result.err(), Some(Ok(EventError::AnonClaimWindowFull)));
 }
 
@@ -315,17 +321,18 @@ fn test_anon_window_resets_after_ledger_advance() {
     let organizer = Address::generate(&env);
     let token = Address::generate(&env);
     let event_id = Symbol::new(&env, "anon_wrst");
+    let claimant = Address::generate(&env);
 
     setup_contracts(&env, &client, &organizer, &token);
     create_anon_free_event(&env, &client, &organizer, &token, event_id.clone(), 50);
     client.set_anon_claim_settings(&organizer, &event_id, &2, &100);
 
-    client.claim_anonymous_ticket(&event_id, &0, &commitment(&env, 1));
-    client.claim_anonymous_ticket(&event_id, &0, &commitment(&env, 2));
+    client.claim_anonymous_ticket(&claimant, &event_id, &0, &commitment(&env, 1));
+    client.claim_anonymous_ticket(&claimant, &event_id, &0, &commitment(&env, 2));
     env.ledger().with_mut(|li| {
         li.sequence_number = 1_100;
     });
-    client.claim_anonymous_ticket(&event_id, &0, &commitment(&env, 3));
+    client.claim_anonymous_ticket(&claimant, &event_id, &0, &commitment(&env, 3));
 
     let event = client.get_event(&event_id);
     assert_eq!(event.sold_count, 3);
@@ -338,14 +345,15 @@ fn test_anon_window_straddle_boundary() {
     let organizer = Address::generate(&env);
     let token = Address::generate(&env);
     let event_id = Symbol::new(&env, "anon_strd");
+    let claimant = Address::generate(&env);
 
     setup_contracts(&env, &client, &organizer, &token);
     create_anon_free_event(&env, &client, &organizer, &token, event_id.clone(), 50);
     client.set_anon_claim_settings(&organizer, &event_id, &1, &10);
     env.ledger().with_mut(|li| li.sequence_number = 1_009);
-    client.claim_anonymous_ticket(&event_id, &0, &commitment(&env, 1));
+    client.claim_anonymous_ticket(&claimant, &event_id, &0, &commitment(&env, 1));
     env.ledger().with_mut(|li| li.sequence_number = 1_010);
-    client.claim_anonymous_ticket(&event_id, &0, &commitment(&env, 2));
+    client.claim_anonymous_ticket(&claimant, &event_id, &0, &commitment(&env, 2));
 
     let event = client.get_event(&event_id);
     assert_eq!(event.sold_count, 2);
@@ -358,6 +366,7 @@ fn test_single_source_rate_limited_per_window() {
     let organizer = Address::generate(&env);
     let token = Address::generate(&env);
     let event_id = Symbol::new(&env, "anon_drain");
+    let claimant = Address::generate(&env);
 
     setup_contracts(&env, &client, &organizer, &token);
     let total_capacity = 5u32;
@@ -370,11 +379,11 @@ fn test_single_source_rate_limited_per_window() {
         total_capacity,
     );
     client.set_anon_claim_settings(&organizer, &event_id, &2, &100);
-    client.claim_anonymous_ticket(&event_id, &0, &commitment(&env, 1));
-    client.claim_anonymous_ticket(&event_id, &0, &commitment(&env, 2));
-    let r3 = client.try_claim_anonymous_ticket(&event_id, &0, &commitment(&env, 3));
-    let r4 = client.try_claim_anonymous_ticket(&event_id, &0, &commitment(&env, 4));
-    let r5 = client.try_claim_anonymous_ticket(&event_id, &0, &commitment(&env, 5));
+    client.claim_anonymous_ticket(&claimant, &event_id, &0, &commitment(&env, 1));
+    client.claim_anonymous_ticket(&claimant, &event_id, &0, &commitment(&env, 2));
+    let r3 = client.try_claim_anonymous_ticket(&claimant, &event_id, &0, &commitment(&env, 3));
+    let r4 = client.try_claim_anonymous_ticket(&claimant, &event_id, &0, &commitment(&env, 4));
+    let r5 = client.try_claim_anonymous_ticket(&claimant, &event_id, &0, &commitment(&env, 5));
 
     assert_eq!(r3.err(), Some(Ok(EventError::AnonClaimWindowFull)));
     assert_eq!(r4.err(), Some(Ok(EventError::AnonClaimWindowFull)));
@@ -393,19 +402,20 @@ fn test_anon_claim_event_sold_out() {
     let organizer = Address::generate(&env);
     let token = Address::generate(&env);
     let event_id = Symbol::new(&env, "anon_sol");
+    let claimant = Address::generate(&env);
 
     setup_contracts(&env, &client, &organizer, &token);
     create_anon_free_event(&env, &client, &organizer, &token, event_id.clone(), 2);
-    client.claim_anonymous_ticket(&event_id, &0, &commitment(&env, 1));
+    client.claim_anonymous_ticket(&claimant, &event_id, &0, &commitment(&env, 1));
 
     env.ledger().with_mut(|li| {
         li.sequence_number = 1_100;
     });
-    client.claim_anonymous_ticket(&event_id, &0, &commitment(&env, 2));
+    client.claim_anonymous_ticket(&claimant, &event_id, &0, &commitment(&env, 2));
     env.ledger().with_mut(|li| {
         li.sequence_number = 1_200;
     });
-    let result = client.try_claim_anonymous_ticket(&event_id, &0, &commitment(&env, 3));
+    let result = client.try_claim_anonymous_ticket(&claimant, &event_id, &0, &commitment(&env, 3));
     assert_eq!(result.err(), Some(Ok(EventError::EventSoldOut)));
 }
 
@@ -417,6 +427,7 @@ fn test_anon_claim_tier_sold_out() {
     let organizer = Address::generate(&env);
     let token = Address::generate(&env);
     let event_id = Symbol::new(&env, "anon_tso");
+    let claimant = Address::generate(&env);
 
     setup_contracts(&env, &client, &organizer, &token);
     let params = CreateEventParams {
@@ -454,7 +465,35 @@ fn test_anon_claim_tier_sold_out() {
     };
     client.create_event(&params);
     client.update_event_status(&organizer, &event_id, &EventStatus::Active);
-    client.claim_anonymous_ticket(&event_id, &0, &commitment(&env, 1));
-    let result = client.try_claim_anonymous_ticket(&event_id, &0, &commitment(&env, 2));
+    client.claim_anonymous_ticket(&claimant, &event_id, &0, &commitment(&env, 1));
+    let result = client.try_claim_anonymous_ticket(&claimant, &event_id, &0, &commitment(&env, 2));
     assert_eq!(result.err(), Some(Ok(EventError::TierSoldOut)));
+}
+
+#[test]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn test_front_running_commitment_theft_fails() {
+    // A bot watches the mempool, copies the (public) commitment bytes from a
+    // real user's pending claim, and tries to submit them first as its own
+    // transaction, naming itself as claimant. Without the real claimant's
+    // signature this must fail auth -- it must not be enough to merely know
+    // the commitment.
+    let env = setup_env();
+    let contract_id = env.register(EventContract, ());
+    let client = EventContractClient::new(&env, &contract_id);
+    let organizer = Address::generate(&env);
+    let token = Address::generate(&env);
+    let event_id = Symbol::new(&env, "anon_front");
+    let attacker_bot = Address::generate(&env);
+
+    setup_contracts(&env, &client, &organizer, &token);
+    create_anon_free_event(&env, &client, &organizer, &token, event_id.clone(), 10);
+
+    let stolen_commitment = commitment(&env, 7);
+
+    // The attacker has no signature from the real claimant and cannot forge
+    // one, so clearing mocked auths means `require_auth` on the bot's own
+    // claim fails.
+    env.set_auths(&[]);
+    client.claim_anonymous_ticket(&attacker_bot, &event_id, &0, &stolen_commitment);
 }

--- a/contracts/ticket/src/lib.rs
+++ b/contracts/ticket/src/lib.rs
@@ -149,14 +149,23 @@ impl TicketContract {
             .unwrap_or(vec![&env])
     }
 
-    pub fn use_ticket(env: Env, organizer: Address, ticket_id: u64) -> Result<(), TicketError> {
+    pub fn use_ticket(
+        env: Env,
+        organizer: Address,
+        owner: Address,
+        ticket_id: u64,
+    ) -> Result<(), TicketError> {
         organizer.require_auth();
+        owner.require_auth();
         let mut ticket: Ticket = env
             .storage()
             .persistent()
             .get(&DataKey::Ticket(ticket_id))
             .ok_or(TicketError::TicketNotFound)?;
         if ticket.organizer != organizer {
+            return Err(TicketError::Unauthorized);
+        }
+        if ticket.owner != owner {
             return Err(TicketError::Unauthorized);
         }
         if ticket.is_used {

--- a/contracts/ticket/src/test.rs
+++ b/contracts/ticket/src/test.rs
@@ -228,7 +228,7 @@ fn test_use_ticket_happy_path() {
         ticket_id,
         TicketStatus::Valid,
     );
-    client.use_ticket(&organizer, &ticket_id);
+    client.use_ticket(&organizer, &owner, &ticket_id);
     let ticket: Ticket = env.as_contract(&contract_id, || {
         env.storage()
             .persistent()
@@ -267,7 +267,7 @@ fn test_use_ticket_double_checkin() {
             .persistent()
             .set(&DataKey::Ticket(ticket_id), &ticket);
     });
-    client.use_ticket(&organizer, &ticket_id);
+    client.use_ticket(&organizer, &owner, &ticket_id);
 }
 
 #[test]
@@ -292,7 +292,34 @@ fn test_use_ticket_unauthorized() {
         ticket_id,
         TicketStatus::Valid,
     );
-    client.use_ticket(&random_person, &ticket_id);
+    client.use_ticket(&random_person, &owner, &ticket_id);
+}
+
+#[test]
+#[should_panic(expected = "HostError: Error(Contract, #4)")]
+fn test_use_ticket_wrong_owner_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(TicketContract, ());
+    let client = TicketContractClient::new(&env, &contract_id);
+
+    let organizer = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let impostor_owner = Address::generate(&env);
+    let ticket_id = 1;
+
+    setup_test_ticket(
+        &env,
+        &contract_id,
+        &organizer,
+        &owner,
+        ticket_id,
+        TicketStatus::Valid,
+    );
+    // The organizer alone cannot check the ticket in for someone other than
+    // its actual owner -- the real owner never authorized this check-in.
+    client.use_ticket(&organizer, &impostor_owner, &ticket_id);
 }
 
 #[test]
@@ -316,7 +343,7 @@ fn test_use_ticket_cancelled() {
         ticket_id,
         TicketStatus::Cancelled,
     );
-    client.use_ticket(&organizer, &ticket_id);
+    client.use_ticket(&organizer, &owner, &ticket_id);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes two related Medium-severity auth gaps in the same trust model — actors performing on-chain actions without proving they are the party entitled to do so:

- **#143**: `claim_anonymous_ticket` accepted any `commitment` with no signature or proof of ownership. A bot watching the mempool could copy a published commitment and front-run the real claimant, or spam distinct dummy commitments to exhaust tier/event capacity and rate-limit windows.
- **#144**: `use_ticket` only verified organizer auth. An organizer could unilaterally mark a ticket `is_used = true` without the ticket holder's presence or consent, blocking the holder from later transferring or claiming a refund.

## Changes

- `claim_anonymous_ticket` now takes a `claimant: Address` and calls `claimant.require_auth()` before touching any state. A front-runner can still read the public commitment bytes off the mempool, but cannot produce the real claimant's signature, so the copied claim fails auth.
- `use_ticket` now takes an additional `owner: Address`, requires `owner.require_auth()`, and verifies `ticket.owner == owner` alongside the existing organizer check. Check-in now requires both parties' consent.
- Existing test suites updated for the new signatures; two new tests added:
  - `test_front_running_commitment_theft_fails` (event contract) — an attacker clears mocked auths and attempts to submit a copied commitment as their own claim; asserts it panics on auth.
  - `test_use_ticket_wrong_owner_rejected` (ticket contract) — organizer attempts check-in against an address that isn't the real ticket owner; asserts `Unauthorized`.
- `TICKET_CONSUMPTION_IMPLEMENTATION.md` updated to document the new `use_ticket` signature and dual-auth model.

## Test plan
- [x] `cargo test --workspace` — 174 tests passing, 0 failed (event-contract 128, ticket-contract 24, payments-contract 135, privacy-utils 11)
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] New front-running test scenario fails to steal commitments (asserted via `should_panic`)
- [x] New unauthorized check-in test confirms an organizer cannot check in a ticket against the wrong owner

Closes #143
Closes #144

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Ticket check-in now requires authorization from both the organizer and ticket owner.
  - Anonymous ticket claims require claimant authorization, helping prevent unauthorized commitment use.

- **Bug Fixes**
  - Incorrect ticket owners are rejected during check-in.
  - Reusing stolen anonymous claim commitments is prevented.

- **API Updates**
  - Ticket check-in and anonymous claim operations now require explicit owner or claimant details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->